### PR TITLE
GTFS-RT > static<>real-time matching (out-of-sync `trip_id`...) & tests

### DIFF
--- a/src/main/java/org/mtransit/android/commons/PreferenceUtils.java
+++ b/src/main/java/org/mtransit/android/commons/PreferenceUtils.java
@@ -443,6 +443,14 @@ public class PreferenceUtils {
 		savePrefLclAsync(context, prefKey, newValue);
 	}
 
+	@WorkerThread
+	public static void savePrefLclSync(@Nullable final Context context, @NonNull final String prefKey, @Nullable final Boolean newValue) {
+		if (context == null) {
+			return;
+		}
+		savePref(getPrefLcl(context), prefKey, newValue);
+	}
+
 	@MainThread
 	public static void savePrefLclAsync(@NonNull Context context, @NonNull String prefKey, @Nullable Boolean newValue) {
 		new MTAsyncTask<Void, Void, Void>() {

--- a/src/main/java/org/mtransit/android/commons/data/DefaultPOI.java
+++ b/src/main/java/org/mtransit/android/commons/data/DefaultPOI.java
@@ -67,7 +67,8 @@ public class DefaultPOI implements POI {
 
 	@Override
 	public boolean equals(Object o) {
-		if (!(o instanceof DefaultPOI)) return false;
+		if (o == null) return false;
+		if (this.getClass() != o.getClass()) return false;
 		final DefaultPOI that = (DefaultPOI) o;
 		return id == that.id
 				&& authority.equals(that.authority)

--- a/src/main/java/org/mtransit/android/commons/data/DefaultPOI.java
+++ b/src/main/java/org/mtransit/android/commons/data/DefaultPOI.java
@@ -67,30 +67,37 @@ public class DefaultPOI implements POI {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o == null) {
-			return false;
-		}
-		if (this.getClass() != o.getClass()) {
-			return false;
-		}
-		DefaultPOI otherPOI = (DefaultPOI) o;
-		if (!this.getUUID().equals(otherPOI.getUUID())) {
-			return false;
-		}
-		if (this.getType() != otherPOI.getType()) {
-			return false;
-		}
-		if (this.getStatusType() != otherPOI.getStatusType()) {
-			return false;
-		}
-		if (this.getActionsType() != otherPOI.getActionsType()) {
-			return false;
-		}
-		//noinspection RedundantIfStatement
-		if (!Objects.equals(this.getName(), otherPOI.getName())) {
-			return false;
-		}
-		return true;
+		if (!(o instanceof DefaultPOI)) return false;
+		final DefaultPOI that = (DefaultPOI) o;
+		return id == that.id
+				&& authority.equals(that.authority)
+				&& name.equals(that.name)
+				&& Double.compare(lat, that.lat) == 0
+				&& Double.compare(lng, that.lng) == 0
+				&& accessible == that.accessible
+				&& type == that.type
+				&& dataSourceTypeId == that.dataSourceTypeId
+				&& statusType == that.statusType
+				&& actionsType == that.actionsType
+				&& Objects.equals(scoreOpt, that.scoreOpt)
+				;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = 0;
+		result = 31 * result + id;
+		result = 31 * result + authority.hashCode();
+		result = 31 * result + name.hashCode();
+		result = 31 * result + Double.hashCode(lat);
+		result = 31 * result + Double.hashCode(lng);
+		result = 31 * result + accessible;
+		result = 31 * result + type;
+		result = 31 * result + dataSourceTypeId;
+		result = 31 * result + statusType;
+		result = 31 * result + actionsType;
+		result = 31 * result + Objects.hashCode(scoreOpt);
+		return result;
 	}
 
 	@NonNull

--- a/src/main/java/org/mtransit/android/commons/data/DefaultPOI.java
+++ b/src/main/java/org/mtransit/android/commons/data/DefaultPOI.java
@@ -86,19 +86,19 @@ public class DefaultPOI implements POI {
 
 	@Override
 	public int hashCode() {
-		int result = 0;
-		result = 31 * result + id;
-		result = 31 * result + authority.hashCode();
-		result = 31 * result + name.hashCode();
-		result = 31 * result + Double.hashCode(lat);
-		result = 31 * result + Double.hashCode(lng);
-		result = 31 * result + accessible;
-		result = 31 * result + type;
-		result = 31 * result + dataSourceTypeId;
-		result = 31 * result + statusType;
-		result = 31 * result + actionsType;
-		result = 31 * result + Objects.hashCode(scoreOpt);
-		return result;
+		return Objects.hash(
+				id,
+				authority,
+				name,
+				lat,
+				lng,
+				accessible,
+				type,
+				dataSourceTypeId,
+				statusType,
+				actionsType,
+				scoreOpt
+		);
 	}
 
 	@NonNull

--- a/src/main/java/org/mtransit/android/commons/data/Direction.java
+++ b/src/main/java/org/mtransit/android/commons/data/Direction.java
@@ -289,13 +289,13 @@ public class Direction implements Targetable {
 
 	@Override
 	public int hashCode() {
-		int result = 0;
-		result = 31 * result + Long.hashCode(id);
-		result = 31 * result + authority.hashCode();
-		result = 31 * result + headsignType;
-		result = 31 * result + headsignValue.hashCode();
-		result = 31 * result + Long.hashCode(routeId);
-		return result;
+		return Objects.hash(
+				id,
+				authority,
+				headsignType,
+				headsignValue,
+				routeId
+		);
 	}
 
 	public static class HeadSignComparator implements Comparator<Direction>, MTLog.Loggable {

--- a/src/main/java/org/mtransit/android/commons/data/Direction.java
+++ b/src/main/java/org/mtransit/android/commons/data/Direction.java
@@ -276,6 +276,7 @@ public class Direction implements Targetable {
 
 	@Override
 	public boolean equals(Object o) {
+		if (o == null) return false;
 		if (!(o instanceof Direction)) return false;
 		final Direction direction = (Direction) o;
 		return id == direction.id

--- a/src/main/java/org/mtransit/android/commons/data/Direction.java
+++ b/src/main/java/org/mtransit/android/commons/data/Direction.java
@@ -20,6 +20,7 @@ import org.mtransit.android.commons.provider.GTFSProviderContract;
 
 import java.lang.annotation.Retention;
 import java.util.Comparator;
+import java.util.Objects;
 
 @SuppressWarnings("WeakerAccess")
 public class Direction implements Targetable {
@@ -271,6 +272,29 @@ public class Direction implements Targetable {
 
 	public long getRouteId() {
 		return routeId;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof Direction)) return false;
+		final Direction direction = (Direction) o;
+		return id == direction.id
+				&& authority.equals(direction.authority)
+				&& headsignType == direction.headsignType
+				&& headsignValue.equals(direction.headsignValue)
+				&& routeId == direction.routeId
+				;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = 0;
+		result = 31 * result + Long.hashCode(id);
+		result = 31 * result + authority.hashCode();
+		result = 31 * result + headsignType;
+		result = 31 * result + headsignValue.hashCode();
+		result = 31 * result + Long.hashCode(routeId);
+		return result;
 	}
 
 	public static class HeadSignComparator implements Comparator<Direction>, MTLog.Loggable {

--- a/src/main/java/org/mtransit/android/commons/data/Route.java
+++ b/src/main/java/org/mtransit/android/commons/data/Route.java
@@ -107,6 +107,7 @@ public class Route implements Targetable, MTLog.Loggable {
 	@Nullable
 	private Integer colorInt;
 
+	@SuppressWarnings("unused") // main app only
 	@ColorInt
 	public int getColorInt() {
 		if (this.colorInt == null) {
@@ -117,6 +118,7 @@ public class Route implements Targetable, MTLog.Loggable {
 
 	@Override
 	public boolean equals(Object o) {
+		if (o == null) return false;
 		if (!(o instanceof Route)) return false;
 		final Route route = (Route) o;
 		return id == route.id
@@ -126,7 +128,6 @@ public class Route implements Targetable, MTLog.Loggable {
 				&& color.equals(route.color)
 				&& Objects.equals(originalIdHash, route.originalIdHash)
 				&& Objects.equals(type, route.type)
-				&& Objects.equals(colorInt, route.colorInt)
 				;
 	}
 
@@ -140,7 +141,6 @@ public class Route implements Targetable, MTLog.Loggable {
 		result = 31 * result + color.hashCode();
 		result = 31 * result + Objects.hashCode(originalIdHash);
 		result = 31 * result + Objects.hashCode(type);
-		result = 31 * result + Objects.hashCode(colorInt);
 		return result;
 	}
 

--- a/src/main/java/org/mtransit/android/commons/data/Route.java
+++ b/src/main/java/org/mtransit/android/commons/data/Route.java
@@ -133,15 +133,15 @@ public class Route implements Targetable, MTLog.Loggable {
 
 	@Override
 	public int hashCode() {
-		int result = 0;
-		result = 31 * result + Long.hashCode(id);
-		result = 31 * result + authority.hashCode();
-		result = 31 * result + shortName.hashCode();
-		result = 31 * result + longName.hashCode();
-		result = 31 * result + color.hashCode();
-		result = 31 * result + Objects.hashCode(originalIdHash);
-		result = 31 * result + Objects.hashCode(type);
-		return result;
+		return Objects.hash(
+				id,
+				authority,
+				shortName,
+				longName,
+				color,
+				originalIdHash,
+				type
+		);
 	}
 
 	@NonNull

--- a/src/main/java/org/mtransit/android/commons/data/Route.java
+++ b/src/main/java/org/mtransit/android/commons/data/Route.java
@@ -117,24 +117,31 @@ public class Route implements Targetable, MTLog.Loggable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (!(o instanceof Route)) {
-			return false;
-		}
-		Route otherRoute = (Route) o;
-		if (getId() != otherRoute.getId()) {
-			return false;
-		}
-		if (!Objects.equals(getShortName(), otherRoute.getShortName())) {
-			return false;
-		}
-		if (!Objects.equals(getLongName(), otherRoute.getLongName())) {
-			return false;
-		}
-		//noinspection RedundantIfStatement
-		if (!Objects.equals(getColor(), otherRoute.getColor())) {
-			return false;
-		}
-		return true;
+		if (!(o instanceof Route)) return false;
+		final Route route = (Route) o;
+		return id == route.id
+				&& authority.equals(route.authority)
+				&& shortName.equals(route.shortName)
+				&& longName.equals(route.longName)
+				&& color.equals(route.color)
+				&& Objects.equals(originalIdHash, route.originalIdHash)
+				&& Objects.equals(type, route.type)
+				&& Objects.equals(colorInt, route.colorInt)
+				;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = 0;
+		result = 31 * result + Long.hashCode(id);
+		result = 31 * result + authority.hashCode();
+		result = 31 * result + shortName.hashCode();
+		result = 31 * result + longName.hashCode();
+		result = 31 * result + color.hashCode();
+		result = 31 * result + Objects.hashCode(originalIdHash);
+		result = 31 * result + Objects.hashCode(type);
+		result = 31 * result + Objects.hashCode(colorInt);
+		return result;
 	}
 
 	@NonNull

--- a/src/main/java/org/mtransit/android/commons/data/RouteDirection.java
+++ b/src/main/java/org/mtransit/android/commons/data/RouteDirection.java
@@ -15,6 +15,7 @@ import org.mtransit.commons.GTFSCommons;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 
 public class RouteDirection implements Targetable, MTLog.Loggable {
 
@@ -71,10 +72,10 @@ public class RouteDirection implements Targetable, MTLog.Loggable {
 
 	@Override
 	public int hashCode() {
-		int result = 0;
-		result = 31 * result + route.hashCode();
-		result = 31 * result + direction.hashCode();
-		return result;
+		return Objects.hash(
+				route,
+				direction
+		);
 	}
 
 	@NonNull

--- a/src/main/java/org/mtransit/android/commons/data/RouteDirection.java
+++ b/src/main/java/org/mtransit/android/commons/data/RouteDirection.java
@@ -59,6 +59,23 @@ public class RouteDirection implements Targetable, MTLog.Loggable {
 		return getRoute().getId() == routeId && getDirection().getId() == directionIdId;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof RouteDirection)) return false;
+		final RouteDirection that = (RouteDirection) o;
+		return route.equals(that.route)
+				&& direction.equals(that.direction)
+				;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = 0;
+		result = 31 * result + route.hashCode();
+		result = 31 * result + direction.hashCode();
+		return result;
+	}
+
 	@NonNull
 	@Override
 	public String toString() {

--- a/src/main/java/org/mtransit/android/commons/data/RouteDirection.java
+++ b/src/main/java/org/mtransit/android/commons/data/RouteDirection.java
@@ -61,6 +61,7 @@ public class RouteDirection implements Targetable, MTLog.Loggable {
 
 	@Override
 	public boolean equals(Object o) {
+		if (o == null) return false;
 		if (!(o instanceof RouteDirection)) return false;
 		final RouteDirection that = (RouteDirection) o;
 		return route.equals(that.route)

--- a/src/main/java/org/mtransit/android/commons/data/RouteDirectionStop.java
+++ b/src/main/java/org/mtransit/android/commons/data/RouteDirectionStop.java
@@ -27,6 +27,7 @@ import org.mtransit.commons.GTFSCommons;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 
 public class RouteDirectionStop extends DefaultPOI {
 
@@ -152,6 +153,30 @@ public class RouteDirectionStop extends DefaultPOI {
 
 	public boolean equals(int routeId, int directionIdId, int stopId) {
 		return getRoute().getId() == routeId && getDirection().getId() == directionIdId && getStop().getId() == stopId;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof RouteDirectionStop)) return false;
+		if (!super.equals(o)) return false;
+		final RouteDirectionStop that = (RouteDirectionStop) o;
+		return route.equals(that.route)
+				&& direction.equals(that.direction)
+				&& stop.equals(that.stop)
+				&& noPickup == that.noPickup
+				&& Objects.equals(alwaysLastTripStop, that.alwaysLastTripStop)
+				;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = 0;
+		result = 31 * result + route.hashCode();
+		result = 31 * result + direction.hashCode();
+		result = 31 * result + stop.hashCode();
+		result = 31 * result + Boolean.hashCode(noPickup);
+		result = 31 * result + Objects.hashCode(alwaysLastTripStop);
+		return result;
 	}
 
 	@NonNull

--- a/src/main/java/org/mtransit/android/commons/data/RouteDirectionStop.java
+++ b/src/main/java/org/mtransit/android/commons/data/RouteDirectionStop.java
@@ -171,13 +171,14 @@ public class RouteDirectionStop extends DefaultPOI {
 
 	@Override
 	public int hashCode() {
-		int result = 0;
-		result = 31 * result + route.hashCode();
-		result = 31 * result + direction.hashCode();
-		result = 31 * result + stop.hashCode();
-		result = 31 * result + Boolean.hashCode(noPickup);
-		result = 31 * result + Objects.hashCode(alwaysLastTripStop);
-		return result;
+		return Objects.hash(
+				super.hashCode(),
+				route,
+				direction,
+				stop,
+				noPickup,
+				alwaysLastTripStop
+		);
 	}
 
 	@NonNull

--- a/src/main/java/org/mtransit/android/commons/data/RouteDirectionStop.java
+++ b/src/main/java/org/mtransit/android/commons/data/RouteDirectionStop.java
@@ -157,6 +157,7 @@ public class RouteDirectionStop extends DefaultPOI {
 
 	@Override
 	public boolean equals(Object o) {
+		if (o == null) return false;
 		if (!(o instanceof RouteDirectionStop)) return false;
 		if (!super.equals(o)) return false;
 		final RouteDirectionStop that = (RouteDirectionStop) o;

--- a/src/main/java/org/mtransit/android/commons/data/ServiceUpdate.java
+++ b/src/main/java/org/mtransit/android/commons/data/ServiceUpdate.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import org.mtransit.android.commons.ComparatorUtils;
 import org.mtransit.android.commons.CursorExtKt;
@@ -256,6 +257,11 @@ public class ServiceUpdate implements MTLog.Loggable {
 
 	public boolean isUseful() {
 		return this.lastUpdateInMs + this.maxValidityInMs >= TimeUtils.currentTimeMillis();
+	}
+
+	@VisibleForTesting
+	protected long getMaxValidityInMs() {
+		return maxValidityInMs;
 	}
 
 	@Nullable

--- a/src/main/java/org/mtransit/android/commons/data/Stop.java
+++ b/src/main/java/org/mtransit/android/commons/data/Stop.java
@@ -214,6 +214,7 @@ public class Stop {
 
 	@Override
 	public boolean equals(Object o) {
+		if (o == null) return false;
 		if (!(o instanceof Stop)) return false;
 		final Stop stop = (Stop) o;
 		return id == stop.id

--- a/src/main/java/org/mtransit/android/commons/data/Stop.java
+++ b/src/main/java/org/mtransit/android/commons/data/Stop.java
@@ -15,6 +15,8 @@ import org.mtransit.android.commons.MTLog;
 import org.mtransit.android.commons.provider.GTFSProviderContract;
 import org.mtransit.commons.GTFSCommons;
 
+import java.util.Objects;
+
 @SuppressWarnings("WeakerAccess")
 public class Stop {
 
@@ -208,5 +210,31 @@ public class Stop {
 		if (this.originalIdHash == null) return false;
 		return this.originalIdHash.toString().equals(cleanedOriginalIdHash);
 
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof Stop)) return false;
+		final Stop stop = (Stop) o;
+		return id == stop.id
+				&& code.equals(stop.code)
+				&& name.equals(stop.name)
+				&& Double.compare(lat, stop.lat) == 0
+				&& Double.compare(lng, stop.lng) == 0
+				&& accessible == stop.accessible
+				&& Objects.equals(originalIdHash, stop.originalIdHash);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = 0;
+		result = 31 * result + id;
+		result = 31 * result + code.hashCode();
+		result = 31 * result + name.hashCode();
+		result = 31 * result + Double.hashCode(lat);
+		result = 31 * result + Double.hashCode(lng);
+		result = 31 * result + accessible;
+		result = 31 * result + Objects.hashCode(originalIdHash);
+		return result;
 	}
 }

--- a/src/main/java/org/mtransit/android/commons/data/Stop.java
+++ b/src/main/java/org/mtransit/android/commons/data/Stop.java
@@ -228,14 +228,14 @@ public class Stop {
 
 	@Override
 	public int hashCode() {
-		int result = 0;
-		result = 31 * result + id;
-		result = 31 * result + code.hashCode();
-		result = 31 * result + name.hashCode();
-		result = 31 * result + Double.hashCode(lat);
-		result = 31 * result + Double.hashCode(lng);
-		result = 31 * result + accessible;
-		result = 31 * result + Objects.hashCode(originalIdHash);
-		return result;
+		return Objects.hash(
+				id,
+				code,
+				name,
+				lat,
+				lng,
+				accessible,
+				originalIdHash
+		);
 	}
 }

--- a/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
+++ b/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
@@ -892,7 +892,6 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 					final String sourceLabel = SourceUtils.getSourceLabel( // always use source from official API
 							getAgencyServiceAlertsUrlString(context, "T")
 					);
-					final boolean ignoreDirection = isIGNORE_DIRECTION(context);
 					try {
 						GtfsRealtime.FeedMessage gFeedMessage = GtfsRealtime.FeedMessage.parseFrom(response.body().bytes());
 						List<Pair<GtfsRealtime.Alert, String>> alertsWithIdPair = GtfsRealtimeExt.toAlertsWithIdPair(gFeedMessage.getEntityList());
@@ -903,7 +902,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 							if (Constants.DEBUG) {
 								MTLog.d(this, "loadAgencyServiceUpdateDataFromWWW() > GTFS - [%s] %s", feedEntityId, GtfsRealtimeExt.toStringExt(gAlert));
 							}
-							final Set<ServiceUpdate> alertsServiceUpdates = processAlerts(context, sourceLabel, feedEntityId, newLastUpdateInMs, gAlert, ignoreDirection);
+							final Set<ServiceUpdate> alertsServiceUpdates = processAlerts(context, sourceLabel, feedEntityId, newLastUpdateInMs, gAlert);
 							if (alertsServiceUpdates != null && !alertsServiceUpdates.isEmpty()) {
 								serviceUpdates.addAll(alertsServiceUpdates);
 							}
@@ -968,8 +967,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 			@NonNull String sourceLabel,
 			@Nullable String feedEntityId,
 			long newLastUpdateInMs,
-			GtfsRealtime.Alert gAlert,
-			boolean ignoreDirection
+			GtfsRealtime.Alert gAlert
 	) {
 		if (gAlert == null) return null;
 		java.util.List<GtfsRealtime.EntitySelector> gInformedEntityList = gAlert.getInformedEntityList();
@@ -993,7 +991,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 				MTLog.w(this, "processAlerts() > Alert targets another agency: %s", gInformedEntity.getAgencyId());
 				continue;
 			}
-			final String targetUUID = GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID(this, gInformedEntity, ignoreDirection);
+			final String targetUUID = GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID(this, gInformedEntity);
 			if (targetUUID == null || targetUUID.isEmpty()) {
 				continue;
 			}

--- a/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
+++ b/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
@@ -906,6 +906,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 					final String sourceLabel = SourceUtils.getSourceLabel( // always use source from official API
 							getAgencyServiceAlertsUrlString(context, "T")
 					);
+					final boolean ignoreDirection = isIGNORE_DIRECTION(context);
 					try {
 						GtfsRealtime.FeedMessage gFeedMessage = GtfsRealtime.FeedMessage.parseFrom(response.body().bytes());
 						List<Pair<GtfsRealtime.Alert, String>> alertsWithIdPair = GtfsRealtimeExt.toAlertsWithIdPair(gFeedMessage.getEntityList());
@@ -916,7 +917,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 							if (Constants.DEBUG) {
 								MTLog.d(this, "loadAgencyServiceUpdateDataFromWWW() > GTFS - [%s] %s", feedEntityId, GtfsRealtimeExt.toStringExt(gAlert));
 							}
-							final Set<ServiceUpdate> alertsServiceUpdates = processAlerts(context, sourceLabel, feedEntityId, newLastUpdateInMs, gAlert);
+							final Set<ServiceUpdate> alertsServiceUpdates = processAlerts(context, sourceLabel, feedEntityId, newLastUpdateInMs, gAlert, ignoreDirection);
 							if (alertsServiceUpdates != null && !alertsServiceUpdates.isEmpty()) {
 								serviceUpdates.addAll(alertsServiceUpdates);
 							}
@@ -982,7 +983,8 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 			@NonNull String sourceLabel,
 			@Nullable String feedEntityId,
 			long newLastUpdateInMs,
-			GtfsRealtime.Alert gAlert
+			GtfsRealtime.Alert gAlert,
+			boolean ignoreDirection
 	) {
 		if (gAlert == null) return null;
 		java.util.List<GtfsRealtime.EntitySelector> gInformedEntityList = gAlert.getInformedEntityList();
@@ -1006,7 +1008,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 				MTLog.w(this, "processAlerts() > Alert targets another agency: %s", gInformedEntity.getAgencyId());
 				continue;
 			}
-			final String targetUUID = GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID(this, gInformedEntity);
+			final String targetUUID = GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID(this, gInformedEntity, ignoreDirection);
 			if (targetUUID == null || targetUUID.isEmpty()) {
 				continue;
 			}

--- a/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
+++ b/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
@@ -419,7 +419,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 	private static String targetAuthority = null;
 
 	/**
-	 * Override if multiple {@link OCTranspoProvider} implementations in same app.
+	 * Override if multiple {@link GTFSRealTimeProvider} implementations in same app.
 	 */
 	@NonNull
 	public static String getTARGET_AUTHORITY(@NonNull Context context) {
@@ -930,7 +930,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 							MTLog.d(this, "loadAgencyServiceUpdateDataFromWWW() > service update: %s.", serviceUpdate);
 						}
 					}
-					GTFSRealTimeServiceAlertsProvider.setServiceUpdatesTripIdsOutOfSync(this, serviceUpdates);
+					GTFSRealTimeServiceAlertsProvider.setTripIdsOutOfSync(this, serviceUpdates);
 					return serviceUpdates;
 				default:
 					MTLog.w(this, "ERROR: HTTP URL-Connection Response Code %s (Message: %s)", response.code(),

--- a/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
+++ b/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
@@ -416,6 +416,20 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 	}
 
 	@Nullable
+	private static String targetAuthority = null;
+
+	/**
+	 * Override if multiple {@link OCTranspoProvider} implementations in same app.
+	 */
+	@NonNull
+	public static String getTARGET_AUTHORITY(@NonNull Context context) {
+		if (targetAuthority == null) {
+			targetAuthority = context.getResources().getString(R.string.gtfs_real_time_for_poi_authority);
+		}
+		return targetAuthority;
+	}
+
+	@Nullable
 	private static Boolean ignoreDirection = null;
 
 	/**
@@ -916,6 +930,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 							MTLog.d(this, "loadAgencyServiceUpdateDataFromWWW() > service update: %s.", serviceUpdate);
 						}
 					}
+					GTFSRealTimeServiceAlertsProvider.setServiceUpdatesTripIdsOutOfSync(this, serviceUpdates);
 					return serviceUpdates;
 				default:
 					MTLog.w(this, "ERROR: HTTP URL-Connection Response Code %s (Message: %s)", response.code(),

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRDSProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRDSProviderExt.kt
@@ -88,7 +88,7 @@ fun Context.getTrips(
             }
             tripIds?.let {
                 if (isNotEmpty()) append(SqlUtils.AND)
-                append(SqlUtils.getWhereIn(GTFSProviderContract.TripColumns.T_TRIP_K_TRIP_ID, it))
+                append(SqlUtils.getWhereInString(GTFSProviderContract.TripColumns.T_TRIP_K_TRIP_ID, it))
             }
         },
         null,

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRDSProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRDSProviderExt.kt
@@ -12,7 +12,7 @@ import org.mtransit.android.commons.provider.poi.POIProviderContract
 
 fun Context.getRDS(
     authority: String,
-    routeId: Long,
+    routeId: Long? = null,
     directionId: Long? = null,
 ): List<RouteDirectionStop>? = try {
     contentResolver.query(
@@ -24,17 +24,20 @@ fun Context.getRDS(
         POIProviderContract.Filter.toJSON(
             POIProviderContract.Filter.getNewSqlSelectionFilter(
                 buildString {
-                    append(
-                        SqlUtils.getWhereEquals(
-                            GTFSProviderContract.RouteDirectionStopColumns.T_ROUTE_K_ID,
-                            routeId
+                    routeId?.let {
+                        append(
+                            SqlUtils.getWhereEquals(
+                                GTFSProviderContract.RouteDirectionStopColumns.T_ROUTE_K_ID,
+                                it
+                            )
                         )
-                    )
+                    }
                     directionId?.let {
-                        append(SqlUtils.AND)
+                        if (isNotEmpty()) append(SqlUtils.AND)
                         append(SqlUtils.getWhereEquals(GTFSProviderContract.RouteDirectionStopColumns.T_DIRECTION_K_ID, it))
                     }
-                })
+                }
+            )
         ).toString(),
         null,
         SqlUtils.getSortOrderAscending(GTFSProviderContract.RouteDirectionStopColumns.T_DIRECTION_STOPS_K_STOP_SEQUENCE)
@@ -57,10 +60,12 @@ fun Context.getRDS(
 fun Context.getTripIds(authority: String, routeId: Long, directionId: Long? = null) =
     getTrips(authority, routeId, directionId)?.map { it.tripId }
 
+@JvmOverloads
 fun Context.getTrips(
     authority: String,
-    routeId: Long,
+    routeId: Long? = null,
     directionId: Long? = null,
+    tripIds: List<String>? = null,
 ): List<Trip>? = try {
     contentResolver.query(
         Uri.withAppendedPath(
@@ -69,15 +74,21 @@ fun Context.getTrips(
         ),
         GTFSProviderContract.PROJECTION_TRIP,
         buildString {
-            append(
-                SqlUtils.getWhereEquals(
-                    GTFSProviderContract.TripColumns.T_TRIP_K_ROUTE_ID,
-                    routeId
+            routeId?.let {
+                append(
+                    SqlUtils.getWhereEquals(
+                        GTFSProviderContract.TripColumns.T_TRIP_K_ROUTE_ID,
+                        it
+                    )
                 )
-            )
+            }
             directionId?.let {
-                append(SqlUtils.AND)
+                if (isNotEmpty()) append(SqlUtils.AND)
                 append(SqlUtils.getWhereEquals(GTFSProviderContract.TripColumns.T_TRIP_K_DIRECTION_ID, it))
+            }
+            tripIds?.let {
+                if (isNotEmpty()) append(SqlUtils.AND)
+                append(SqlUtils.getWhereIn(GTFSProviderContract.TripColumns.T_TRIP_K_TRIP_ID, it))
             }
         },
         null,

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
@@ -164,7 +164,7 @@ fun GTFSRealTimeProvider.setTripIdsOutOfSync(
     val context = context ?: return
     val rtTripId = getOneTripId()
     val tripIdsOutOfSync = rtTripId?.let {
-        context.getTrips(targetAuthority, tripIds = listOf(it))?.size == 0 // no trip ID matches == out-of-sync
+        context.getTrips(targetAuthority, tripIds = listOf(it))?.isEmpty() == true // no trip ID matches == out-of-sync
     } ?: false // no real-time trip ID == not out-of-sync
     saveTripIdsOutOfSync(context, tripIdsOutOfSync)
 }

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
@@ -157,6 +157,18 @@ fun Route.getTargetUUIDs(
     put(getAgencyRouteTagTargetUUID(provider.agencyTag, getRouteTag(provider)), uuid)
 }
 
+fun GTFSRealTimeProvider.setTripIdsOutOfSync(
+    getOneTripId: () -> String?,
+    saveTripIdsOutOfSync: (context: Context, tripIdsOutOfSync: Boolean) -> Unit,
+) {
+    val context = context ?: return
+    val rtTripId = getOneTripId()
+    val tripIdsOutOfSync = rtTripId?.let {
+        context.getTrips(targetAuthority, tripIds = listOf(it))?.size == 0 // no trip ID matches == out-of-sync
+    } ?: false // no real-time trip ID == not out-of-sync
+    saveTripIdsOutOfSync(context, tripIdsOutOfSync)
+}
+
 fun GTFSRealTimeProvider.makeRequest(context: Context, urlCachedString: String = "", getUrlString: (token: String) -> String): Request? {
     if (urlCachedString.isNotBlank()) {
         MTLog.i(this, "Loading from cached API (length: %d) '***'...", urlCachedString.length)

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
@@ -34,6 +34,7 @@ import com.google.transit.realtime.GtfsRealtime.EntitySelector as GEntitySelecto
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor as GTripDescriptor
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate as GTUStopTimeUpdate
 
+val Number.isValidDirection get() = this in 0..1
 val GTFSRealTimeProvider.ignoreDirection get() = isIGNORE_DIRECTION(requireContextCompat())
 val GTFSRealTimeProvider.timeZone get() = getAGENCY_TIME_ZONE(requireContextCompat())
 

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
@@ -35,7 +35,7 @@ import com.google.transit.realtime.GtfsRealtime.EntitySelector as GEntitySelecto
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor as GTripDescriptor
 import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate as GTUStopTimeUpdate
 
-val Number.isValidDirection get() = this in 0..1
+val Int.isValidDirection get() = this in 0..1
 val GTFSRealTimeProvider.ignoreDirection get() = isIGNORE_DIRECTION(requireContextCompat())
 val GTFSRealTimeProvider.targetAuthority get() = getTARGET_AUTHORITY(requireContextCompat())
 val GTFSRealTimeProvider.timeZone get() = getAGENCY_TIME_ZONE(requireContextCompat())
@@ -74,6 +74,7 @@ fun RouteDirectionStop.getRouteTag(provider: GTFSRealTimeProvider) = this.route.
 fun RouteDirectionStop.getDirectionTag(provider: GTFSRealTimeProvider) = this.direction.getDirectionTag(provider)
 fun RouteDirectionStop.getStopTag(provider: GTFSRealTimeProvider) = this.stop.getStopTag(provider)
 
+@Suppress("unused")
 fun GTFSRealTimeProviderFilter.getPrimaryTargetUUIDs(
     provider: GTFSRealTimeProvider,
     ignoreDirection: Boolean = false,

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GTFSRealTimeProviderExt.kt
@@ -22,6 +22,7 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRoute
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteTypeTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyStopTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getTARGET_AUTHORITY
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.isIGNORE_DIRECTION
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.isUSE_URL_HASH_SECRET_AND_DATE
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optRouteId
@@ -36,6 +37,7 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate as GTU
 
 val Number.isValidDirection get() = this in 0..1
 val GTFSRealTimeProvider.ignoreDirection get() = isIGNORE_DIRECTION(requireContextCompat())
+val GTFSRealTimeProvider.targetAuthority get() = getTARGET_AUTHORITY(requireContextCompat())
 val GTFSRealTimeProvider.timeZone get() = getAGENCY_TIME_ZONE(requireContextCompat())
 
 private val GTFSRealTimeProvider.routeIdCleanupPattern get() = getRouteIdCleanupPattern(requireContextCompat())

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealTimeStorage.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealTimeStorage.kt
@@ -40,6 +40,22 @@ object GtfsRealTimeStorage {
         PreferenceUtils.savePrefLclSync(context, PREF_KEY_TRIP_UPDATE_LAST_UPDATE_CODE, code)
     }
 
+    /**
+     * Override if multiple {@link GTFSRealTimeDbHelper} implementations in same app.
+     */
+    private const val PREF_KEY_TRIP_UPDATE_TRIP_IDS_OUT_OF_SYNC = "pGTFSRealTimeTripUpdateTripIdsOutOfSync"
+
+    @JvmStatic
+    @WorkerThread
+    fun getTripUpdateTripIdsOutOfSync(context: Context, default: Boolean) =
+        PreferenceUtils.getPrefLcl(context, PREF_KEY_TRIP_UPDATE_TRIP_IDS_OUT_OF_SYNC, default)
+
+    @JvmStatic
+    @WorkerThread
+    fun saveTripUpdateTripIdsOutOfSync(context: Context, outOfSync: Boolean) {
+        PreferenceUtils.savePrefLclSync(context, PREF_KEY_TRIP_UPDATE_TRIP_IDS_OUT_OF_SYNC, outOfSync)
+    }
+
     // end region
 
     // region Vehicle location
@@ -74,6 +90,22 @@ object GtfsRealTimeStorage {
     @WorkerThread
     fun saveVehicleLocationLastUpdateCode(context: Context, code: Int) {
         PreferenceUtils.savePrefLclSync(context, PREF_KEY_VEHICLE_LOCATION_LAST_UPDATE_CODE, code)
+    }
+
+    /**
+     * Override if multiple {@link GTFSRealTimeDbHelper} implementations in same app.
+     */
+    private const val PREF_KEY_VEHICLE_LOCATION_TRIP_IDS_OUT_OF_SYNC = "pGTFSRealTimeVehicleLocationTripIdsOutOfSync"
+
+    @JvmStatic
+    @WorkerThread
+    fun getVehicleLocationTripIdsOutOfSync(context: Context, default: Boolean) =
+        PreferenceUtils.getPrefLcl(context, PREF_KEY_VEHICLE_LOCATION_TRIP_IDS_OUT_OF_SYNC, default)
+
+    @JvmStatic
+    @WorkerThread
+    fun saveVehicleLocationTripIdsOutOfSync(context: Context, outOfSync: Boolean) {
+        PreferenceUtils.savePrefLclSync(context, PREF_KEY_VEHICLE_LOCATION_TRIP_IDS_OUT_OF_SYNC, outOfSync)
     }
 
     // endregion

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealTimeStorage.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealTimeStorage.kt
@@ -128,6 +128,22 @@ object GtfsRealTimeStorage {
         PreferenceUtils.savePrefLclSync(context, PREF_KEY_SERVICE_UPDATE_LANGUAGES, languages)
     }
 
+    /**
+     * Override if multiple {@link GTFSRealTimeDbHelper} implementations in same app.
+     */
+    private const val PREF_KEY_SERVICE_UPDATE_TRIP_IDS_OUT_OF_SYNC = "pGTFSRealTimeServiceAlertsTripIdsOutOfSync"
+
+    @JvmStatic
+    @WorkerThread
+    fun getServiceUpdateTripIdsOutOfSync(context: Context, default: Boolean) =
+        PreferenceUtils.getPrefLcl(context, PREF_KEY_SERVICE_UPDATE_TRIP_IDS_OUT_OF_SYNC, default)
+
+    @JvmStatic
+    @WorkerThread
+    fun saveServiceUpdateTripIdsOutOfSync(context: Context, outOfSync: Boolean) {
+        PreferenceUtils.savePrefLclSync(context, PREF_KEY_SERVICE_UPDATE_TRIP_IDS_OUT_OF_SYNC, outOfSync)
+    }
+
     // endregion
 
 }

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealtimeExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealtimeExt.kt
@@ -471,6 +471,7 @@ object GtfsRealtimeExt {
     val GEntitySelector.optAgencyId get() = if (hasAgencyId()) agencyId else null
     val GEntitySelector.optRouteId get() = if (hasRouteId()) routeId else this.optTrip?.optRouteId
     val GEntitySelector.optDirectionId get() = if (hasDirectionId()) directionId else this.optTrip?.optDirectionId
+    val GEntitySelector.optDirectionIdValid get() = optDirectionId?.takeIf { it.isValidDirection }
     val GEntitySelector.optStopId get() = if (hasStopId()) stopId else null
     val GEntitySelector.optRouteType get() = if (hasRouteType()) routeType else null
     val GEntitySelector.optTrip get() = if (hasTrip()) this.trip else null
@@ -495,6 +496,7 @@ object GtfsRealtimeExt {
     val GTripDescriptor.optTripId get() = if (hasTripId()) tripId else optModifiedTrip?.optAffectedTripId
     val GTripDescriptor.optRouteId get() = if (hasRouteId()) routeId else null
     val GTripDescriptor.optDirectionId get() = if (hasDirectionId()) directionId else null
+    val GTripDescriptor.optDirectionIdValid get() = optDirectionId?.takeIf { it.isValidDirection }
     val GTripDescriptor.optModifiedTrip get() = if (hasModifiedTrip()) modifiedTrip else null
     val GTripDescriptor.optScheduleRelationship get() = if (hasScheduleRelationship()) scheduleRelationship else null
     val GTripDescriptor.optStartDate get() = if (hasStartDate()) startDate else null

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
@@ -27,6 +27,7 @@ import org.mtransit.android.commons.provider.gtfs.ignoreDirection
 import org.mtransit.android.commons.provider.gtfs.parseRouteId
 import org.mtransit.android.commons.provider.gtfs.parseStopId
 import org.mtransit.android.commons.provider.gtfs.parseTripId
+import org.mtransit.android.commons.provider.gtfs.setTripIdsOutOfSync
 import org.mtransit.android.commons.provider.gtfs.targetAuthority
 import com.google.transit.realtime.GtfsRealtime.EntitySelector as GEntitySelector
 
@@ -102,11 +103,10 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
     fun GTFSRealTimeProvider.parseTargetTripId(gEntitySelector: GEntitySelector) =
         gEntitySelector.optTrip?.let { parseTripId(it) }
 
-    @JvmOverloads
     @JvmStatic
     fun GTFSRealTimeProvider.parseProviderTargetUUID(
         gEntitySelector: GEntitySelector,
-        ignoreDirection: Boolean = this.ignoreDirection,
+        ignoreDirection: Boolean,
     ): String? {
         parseRouteId(gEntitySelector)?.let { routeId ->
             gEntitySelector.optDirectionIdValid?.takeIf { !ignoreDirection }?.let { directionId ->
@@ -143,12 +143,12 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
 
     @JvmStatic
     fun GTFSRealTimeProvider.setTripIdsOutOfSync(serviceUpdates: List<ServiceUpdate>) {
-        val context = context ?: return
-        val rtTripId = serviceUpdates.firstOrNull { it.targetTripId != null }?.targetTripId
-        val tripIdsOutOfSync = rtTripId?.let {
-            context.getTrips(targetAuthority, tripIds = listOf(it))?.size == 0 // no trip ID matches == out-of-sync
-        } ?: false // no real-time trip ID == not out-of-sync
-        GtfsRealTimeStorage.saveServiceUpdateTripIdsOutOfSync(context, tripIdsOutOfSync)
-        _tripIdsOutOfSync = tripIdsOutOfSync
+        setTripIdsOutOfSync(
+            getOneTripId = { serviceUpdates.firstOrNull { it.targetTripId != null }?.targetTripId },
+            saveTripIdsOutOfSync = { context, tripIdsOutOfSync ->
+                GtfsRealTimeStorage.saveServiceUpdateTripIdsOutOfSync(context, tripIdsOutOfSync)
+                _tripIdsOutOfSync = tripIdsOutOfSync
+            }
+        )
     }
 }

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
@@ -1,5 +1,6 @@
 package org.mtransit.android.commons.provider.serviceupdate
 
+import androidx.annotation.VisibleForTesting
 import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.data.ServiceUpdate
 import org.mtransit.android.commons.data.makeServiceUpdateNoneList
@@ -55,7 +56,8 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
             },
         )
 
-    fun GTFSRealTimeProvider.getCached(
+    @VisibleForTesting
+    internal fun GTFSRealTimeProvider.getCached(
         filter: ServiceUpdateProviderContract.Filter,
         tripIdsOutOfSync: Boolean?,
         getTripIds: (authority: String, routeId: Long, directionId: Long?) -> List<String>?,
@@ -140,7 +142,7 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
         }
 
     @JvmStatic
-    fun GTFSRealTimeProvider.setServiceUpdatesTripIdsOutOfSync(serviceUpdates: List<ServiceUpdate>) {
+    fun GTFSRealTimeProvider.setTripIdsOutOfSync(serviceUpdates: List<ServiceUpdate>) {
         val context = context ?: return
         val rtTripId = serviceUpdates.firstOrNull { it.targetTripId != null }?.targetTripId
         val tripIdsOutOfSync = rtTripId?.let {

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
@@ -20,6 +20,7 @@ import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optRouteType
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
 import org.mtransit.android.commons.provider.gtfs.agencyTag
+import org.mtransit.android.commons.provider.gtfs.getRouteTypeTag
 import org.mtransit.android.commons.provider.gtfs.getTargetUUIDs
 import org.mtransit.android.commons.provider.gtfs.getTripIds
 import org.mtransit.android.commons.provider.gtfs.getTrips
@@ -65,7 +66,7 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
         getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>?,
     ): List<ServiceUpdate>? {
         val tripIdsOutOfSync = tripIdsOutOfSync == true
-        return filter.getTargetUUIDs(this, includeAgencyTag = !tripIdsOutOfSync, includeRouteType = true, includeStopTags = true)
+        return filter.getTargetUUIDs(this, includeAgencyTag = true, includeRouteType = true, includeStopTags = true)
             ?.let { targetUUIDs ->
                 val tripIds = if (tripIdsOutOfSync) null
                 else filter.targetAuthority?.let { targetAuthority ->
@@ -76,6 +77,18 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
                 targetUUIDs to tripIds?.takeIf { it.isNotEmpty() } // trip IDs not required for GTFS Alerts
             }?.let { (targetUUIDs, tripIds) ->
                 getCached(targetUUIDs, tripIds, getCachedServiceUpdates)
+                    .let { cache ->
+                        if (!tripIdsOutOfSync) return@let cache
+                        if (cache.isEmpty()) return@let cache
+                        val targetUUIDsToBroad = buildList {
+                            add(getAgencyTagTargetUUID(agencyTag))
+                            filter.route?.let { getAgencyRouteTypeTagTargetUUID(agencyTag, getRouteTypeTag(it)) }?.let { add(it) }
+                        }
+                        return@let cache.filterNot { serviceUpdate ->
+                            // remove service updates targeted to the entire agency or all route type for a specific trip ID
+                            serviceUpdate.targetUUID in targetUUIDsToBroad && serviceUpdate.targetTripId != null
+                        }
+                    }
             }
     }
 
@@ -84,9 +97,7 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
         tripIds: List<String>?,
         getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>?,
     ) = buildList {
-        (
-                getCachedServiceUpdates(targetUUIDs.keys, tripIds)?.takeIf { it.isNotEmpty() }
-                )
+        getCachedServiceUpdates(targetUUIDs.keys, tripIds)?.takeIf { it.isNotEmpty() }
             ?.let {
                 addAll(it)
             }

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
@@ -14,6 +14,7 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyStopT
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optAgencyId
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionId
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionIdValid
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optRouteType
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
@@ -75,10 +76,14 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
     fun GTFSRealTimeProvider.parseTargetTripId(gEntitySelector: GEntitySelector) =
         gEntitySelector.optTrip?.let { parseTripId(it) }
 
+    @JvmOverloads
     @JvmStatic
-    fun GTFSRealTimeProvider.parseProviderTargetUUID(gEntitySelector: GEntitySelector, ignoreDirection: Boolean): String? {
+    fun GTFSRealTimeProvider.parseProviderTargetUUID(
+        gEntitySelector: GEntitySelector,
+        ignoreDirection: Boolean = this.ignoreDirection,
+    ): String? {
         parseRouteId(gEntitySelector)?.let { routeId ->
-            gEntitySelector.optDirectionId?.takeIf { !ignoreDirection }?.let { directionId ->
+            gEntitySelector.optDirectionIdValid?.takeIf { !ignoreDirection }?.let { directionId ->
                 parseStopId(gEntitySelector)?.let { stopId ->
                     return getAgencyRouteDirectionStopTagTargetUUID(agencyTag, routeId, directionId, stopId)
                 } // no stop

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
@@ -12,19 +12,21 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRoute
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteTypeTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyStopTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
+import org.mtransit.android.commons.provider.gtfs.GtfsRealTimeStorage
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optAgencyId
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionIdValid
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optRouteType
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
 import org.mtransit.android.commons.provider.gtfs.agencyTag
-import org.mtransit.android.commons.provider.gtfs.getPrimaryTargetUUIDs
 import org.mtransit.android.commons.provider.gtfs.getTargetUUIDs
 import org.mtransit.android.commons.provider.gtfs.getTripIds
+import org.mtransit.android.commons.provider.gtfs.getTrips
 import org.mtransit.android.commons.provider.gtfs.ignoreDirection
 import org.mtransit.android.commons.provider.gtfs.parseRouteId
 import org.mtransit.android.commons.provider.gtfs.parseStopId
 import org.mtransit.android.commons.provider.gtfs.parseTripId
+import org.mtransit.android.commons.provider.gtfs.targetAuthority
 import com.google.transit.realtime.GtfsRealtime.EntitySelector as GEntitySelector
 
 object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
@@ -33,40 +35,54 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
 
     override fun getLogTag() = LOG_TAG
 
+    private var _tripIdsOutOfSync: Boolean? = null
+
+    private fun GTFSRealTimeProvider.getTripIdOutOfSync() = _tripIdsOutOfSync
+        ?: context?.let { GtfsRealTimeStorage.getServiceUpdateTripIdsOutOfSync(it, false) }.also {
+            _tripIdsOutOfSync = it
+        }
+
     @JvmStatic
     fun GTFSRealTimeProvider.getCached(filter: ServiceUpdateProviderContract.Filter) =
-        filter.getTargetUUIDs(this, includeAgencyTag = true, includeRouteType = true, includeStopTags = true)
+        getCached(
+            filter = filter,
+            tripIdsOutOfSync = getTripIdOutOfSync(),
+            getTripIds = { authority, routeId, directionId ->
+                context?.getTripIds(authority, routeId, directionId)
+            },
+            getCachedServiceUpdates = { targetUUIDs, tripIds ->
+                getCachedServiceUpdatesS(targetUUIDs, tripIds)
+            },
+        )
+
+    fun GTFSRealTimeProvider.getCached(
+        filter: ServiceUpdateProviderContract.Filter,
+        tripIdsOutOfSync: Boolean?,
+        getTripIds: (authority: String, routeId: Long, directionId: Long?) -> List<String>?,
+        getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>?,
+    ): List<ServiceUpdate>? {
+        val tripIdsOutOfSync = tripIdsOutOfSync == true
+        return filter.getTargetUUIDs(this, includeAgencyTag = !tripIdsOutOfSync, includeRouteType = true, includeStopTags = true)
             ?.let { targetUUIDs ->
-                val tripIds = filter.targetAuthority?.let { targetAuthority ->
+                val tripIds = if (tripIdsOutOfSync) null
+                else filter.targetAuthority?.let { targetAuthority ->
                     filter.routeId?.let { routeId ->
-                        context?.getTripIds(targetAuthority, routeId, filter.directionId)
+                        getTripIds(targetAuthority, routeId, filter.directionId)
                     }
                 }
                 targetUUIDs to tripIds?.takeIf { it.isNotEmpty() } // trip IDs not required for GTFS Alerts
             }?.let { (targetUUIDs, tripIds) ->
-                getCached(filter, targetUUIDs, tripIds, getCachedServiceUpdates = { targetUUIDs, tripIds ->
-                    getCachedServiceUpdatesS(targetUUIDs, tripIds)
-                })
+                getCached(targetUUIDs, tripIds, getCachedServiceUpdates)
             }
+    }
 
-    fun GTFSRealTimeProvider.getCached(
-        filter: ServiceUpdateProviderContract.Filter,
+    private fun getCached(
         targetUUIDs: Map<String, String>,
         tripIds: List<String>?,
         getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>?,
-        ignoreDirection: Boolean = this.ignoreDirection,
     ) = buildList {
         (
-                // 1 - trip IDs preferred for all result filtered correctly
-                tripIds?.let { getCachedServiceUpdates(targetUUIDs.keys, it) }?.takeIf { it.isNotEmpty() }
-                // 2 - fallback to: ignore TRIP IDS (outdated?) and try using primary target UUID only
-                // - only works if Route & Direction! provided
-                // -> can NOT show service alerts for the wrong direction
-                    ?: if (ignoreDirection) null
-                    else filter.getPrimaryTargetUUIDs(this@getCached, ignoreDirection = false, includeStopTags = true)
-                        ?.let { (providerTargetUUID, _) ->
-                            getCachedServiceUpdates(setOf(providerTargetUUID), null)
-                        }?.takeIf { it.isNotEmpty() }
+                getCachedServiceUpdates(targetUUIDs.keys, tripIds)?.takeIf { it.isNotEmpty() }
                 )
             ?.let {
                 addAll(it)
@@ -122,4 +138,15 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
                 setTextHTML(enhanceHtmlDateTime(requireContextCompat(), serviceUpdate.textHTML))
             }
         }
+
+    @JvmStatic
+    fun GTFSRealTimeProvider.setServiceUpdatesTripIdsOutOfSync(serviceUpdates: List<ServiceUpdate>) {
+        val context = context ?: return
+        val rtTripId = serviceUpdates.firstOrNull { it.targetTripId != null }?.targetTripId
+        val tripIdsOutOfSync = rtTripId?.let {
+            context.getTrips(targetAuthority, tripIds = listOf(it))?.size == 0 // no trip ID matches == out-of-sync
+        } ?: false // no real-time trip ID == not out-of-sync
+        GtfsRealTimeStorage.saveServiceUpdateTripIdsOutOfSync(context, tripIdsOutOfSync)
+        _tripIdsOutOfSync = tripIdsOutOfSync
+    }
 }

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
@@ -66,8 +66,8 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
             ?.let { targetUUIDs ->
                 val tripIds = if (tripIdsOutOfSync) null
                 else filter.targetAuthority?.let { targetAuthority ->
-                    filter.targetRouteId?.let { routeId ->
-                        getTripIds(targetAuthority, routeId, filter.targetDirectionId)
+                    filter.targetRouteId?.let { targetRouteId ->
+                        getTripIds(targetAuthority, targetRouteId, filter.targetDirectionId)
                     }
                 }
                 targetUUIDs to tripIds?.takeIf { it.isNotEmpty() } // trip IDs not required for GTFS Alerts

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
@@ -20,16 +20,12 @@ import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optRouteType
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
 import org.mtransit.android.commons.provider.gtfs.agencyTag
-import org.mtransit.android.commons.provider.gtfs.getRouteTypeTag
 import org.mtransit.android.commons.provider.gtfs.getTargetUUIDs
 import org.mtransit.android.commons.provider.gtfs.getTripIds
-import org.mtransit.android.commons.provider.gtfs.getTrips
-import org.mtransit.android.commons.provider.gtfs.ignoreDirection
 import org.mtransit.android.commons.provider.gtfs.parseRouteId
 import org.mtransit.android.commons.provider.gtfs.parseStopId
 import org.mtransit.android.commons.provider.gtfs.parseTripId
 import org.mtransit.android.commons.provider.gtfs.setTripIdsOutOfSync
-import org.mtransit.android.commons.provider.gtfs.targetAuthority
 import com.google.transit.realtime.GtfsRealtime.EntitySelector as GEntitySelector
 
 object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
@@ -70,8 +66,8 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
             ?.let { targetUUIDs ->
                 val tripIds = if (tripIdsOutOfSync) null
                 else filter.targetAuthority?.let { targetAuthority ->
-                    filter.routeId?.let { routeId ->
-                        getTripIds(targetAuthority, routeId, filter.directionId)
+                    filter.targetRouteId?.let { routeId ->
+                        getTripIds(targetAuthority, routeId, filter.targetDirectionId)
                     }
                 }
                 targetUUIDs to tripIds?.takeIf { it.isNotEmpty() } // trip IDs not required for GTFS Alerts
@@ -82,7 +78,7 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
                         if (cache.isEmpty()) return@let cache
                         val targetUUIDsToBroad = buildList {
                             add(getAgencyTagTargetUUID(agencyTag))
-                            filter.route?.let { getAgencyRouteTypeTagTargetUUID(agencyTag, getRouteTypeTag(it)) }?.let { add(it) }
+                            filter.targetRoute?.let { getAgencyRouteTypeTagTargetUUID(agencyTag, getRouteTypeTag(it)) }?.let { add(it) }
                         }
                         return@let cache.filterNot { serviceUpdate ->
                             // remove service updates targeted to the entire agency or all route type for a specific trip ID

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProvider.kt
@@ -13,7 +13,6 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRoute
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyStopTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optAgencyId
-import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionId
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionIdValid
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optRouteType
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
@@ -45,20 +44,29 @@ object GTFSRealTimeServiceAlertsProvider : MTLog.Loggable {
                 }
                 targetUUIDs to tripIds?.takeIf { it.isNotEmpty() } // trip IDs not required for GTFS Alerts
             }?.let { (targetUUIDs, tripIds) ->
-                getCached(filter, targetUUIDs, tripIds)
+                getCached(filter, targetUUIDs, tripIds, getCachedServiceUpdates = { targetUUIDs, tripIds ->
+                    getCachedServiceUpdatesS(targetUUIDs, tripIds)
+                })
             }
 
-    fun GTFSRealTimeProvider.getCached(filter: ServiceUpdateProviderContract.Filter, targetUUIDs: Map<String, String>, tripIds: List<String>?) = buildList {
+    fun GTFSRealTimeProvider.getCached(
+        filter: ServiceUpdateProviderContract.Filter,
+        targetUUIDs: Map<String, String>,
+        tripIds: List<String>?,
+        getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>?,
+        ignoreDirection: Boolean = this.ignoreDirection,
+    ) = buildList {
         (
                 // 1 - trip IDs preferred for all result filtered correctly
-                tripIds?.let { getCachedServiceUpdatesS(targetUUIDs.keys, tripIds = it) }?.takeIf { it.isNotEmpty() }
+                tripIds?.let { getCachedServiceUpdates(targetUUIDs.keys, it) }?.takeIf { it.isNotEmpty() }
                 // 2 - fallback to: ignore TRIP IDS (outdated?) and try using primary target UUID only
                 // - only works if Route & Direction! provided
                 // -> can NOT show service alerts for the wrong direction
                     ?: if (ignoreDirection) null
-                    else filter.getPrimaryTargetUUIDs(this@getCached, ignoreDirection = false, includeStopTags = true)?.let { (providerTargetUUID, _) ->
-                        getCachedServiceUpdatesS(setOf(providerTargetUUID), tripIds = null)
-                    }?.takeIf { it.isNotEmpty() }
+                    else filter.getPrimaryTargetUUIDs(this@getCached, ignoreDirection = false, includeStopTags = true)
+                        ?.let { (providerTargetUUID, _) ->
+                            getCachedServiceUpdates(setOf(providerTargetUUID), null)
+                        }?.takeIf { it.isNotEmpty() }
                 )
             ?.let {
                 addAll(it)

--- a/src/main/java/org/mtransit/android/commons/provider/serviceupdate/ServiceUpdateProviderContract.java
+++ b/src/main/java/org/mtransit/android/commons/provider/serviceupdate/ServiceUpdateProviderContract.java
@@ -12,6 +12,7 @@ import org.mtransit.android.commons.JSONUtils;
 import org.mtransit.android.commons.MTLog;
 import org.mtransit.android.commons.SecureStringUtils;
 import org.mtransit.android.commons.data.DefaultPOI;
+import org.mtransit.android.commons.data.Direction;
 import org.mtransit.android.commons.data.POI;
 import org.mtransit.android.commons.data.Route;
 import org.mtransit.android.commons.data.RouteDirection;
@@ -209,28 +210,40 @@ public interface ServiceUpdateProviderContract extends ProviderContract {
 		}
 
 		@Nullable
-		public Long getRouteId() {
+		public Route getTargetRoute() {
 			if (this.poi != null && this.poi instanceof RouteDirectionStop) {
-				return ((RouteDirectionStop) this.poi).getRoute().getId();
+				return ((RouteDirectionStop) this.poi).getRoute();
 			}
 			if (this.route != null) {
-				return this.route.getId();
+				return this.route;
 			}
 			if (this.routeDirection != null) {
-				return this.routeDirection.getRoute().getId();
+				return this.routeDirection.getRoute();
 			}
 			return null;
 		}
 
 		@Nullable
-		public Long getDirectionId() {
+		public Long getTargetRouteId() {
+			final Route targetRoute = getTargetRoute();
+			return targetRoute == null ? null : targetRoute.getId();
+		}
+
+		@Nullable
+		public Direction getTargetDirection() {
 			if (this.poi != null && this.poi instanceof RouteDirectionStop) {
-				return ((RouteDirectionStop) this.poi).getDirection().getId();
+				return ((RouteDirectionStop) this.poi).getDirection();
 			}
 			if (this.routeDirection != null) {
-				return this.routeDirection.getDirection().getId();
+				return this.routeDirection.getDirection();
 			}
 			return null;
+		}
+
+		@Nullable
+		public Long getTargetDirectionId() {
+			final Direction targetDirection = getTargetDirection();
+			return targetDirection == null ? null : targetDirection.getId();
 		}
 
 		@Nullable

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -14,7 +14,6 @@ import org.mtransit.android.commons.data.arrival
 import org.mtransit.android.commons.data.departure
 import org.mtransit.android.commons.data.toNoData
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider
-import org.mtransit.android.commons.provider.GTFSRealTimeProvider.isIGNORE_DIRECTION
 import org.mtransit.android.commons.provider.gtfs.GtfsRealTimeStorage
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionIdValid
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
@@ -24,6 +23,7 @@ import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toTripUpdates
 import org.mtransit.android.commons.provider.gtfs.getRDS
 import org.mtransit.android.commons.provider.gtfs.getRDSSchedule
 import org.mtransit.android.commons.provider.gtfs.getTripIds
+import org.mtransit.android.commons.provider.gtfs.ignoreDirection
 import org.mtransit.android.commons.provider.gtfs.makeRequest
 import org.mtransit.android.commons.provider.gtfs.parseRouteId
 import org.mtransit.android.commons.provider.gtfs.parseTripId
@@ -106,8 +106,6 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
                 ?: makeCachedStatusFromAgencyData(context, filter, tripIds)
         }
     }
-
-    val GTFSRealTimeProvider.ignoreDirection get() = isIGNORE_DIRECTION(this.requireContextCompat())
 
     private fun GTFSRealTimeProvider.makeCachedStatusFromAgencyData(
         context: Context,

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -16,7 +16,7 @@ import org.mtransit.android.commons.data.toNoData
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.isIGNORE_DIRECTION
 import org.mtransit.android.commons.provider.gtfs.GtfsRealTimeStorage
-import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionId
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionIdValid
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.sortTripUpdates
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
@@ -130,13 +130,19 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
                     gTripUpdate.optTrip?.let { it to gTripUpdate }
                 }.filter { (td, _) ->
                     parseTripId(td)?.let { tripId ->
-                        if (tripId !in tripIds) return@filter false
+                        if (tripId !in tripIds) {
+                            return@filter false
+                        }
                     }
                     parseRouteId(td)?.let { routeIdHash ->
-                        if (routeIdHash != targetRouteIdHash) return@filter false
+                        if (routeIdHash != targetRouteIdHash) {
+                            return@filter false
+                        }
                     }
-                    td.optDirectionId?.takeIf { !ignoreDirection }?.let { directionId ->
-                        if (directionId != targetDirectionOriginalId) return@filter false
+                    td.optDirectionIdValid?.takeIf { !ignoreDirection }?.let { directionId ->
+                        if (directionId != targetDirectionOriginalId) {
+                            return@filter false
+                        }
                     }
                     return@filter true
                 }.takeIf { it.isNotEmpty() }

--- a/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
@@ -28,13 +28,11 @@ import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toVehicles
 import org.mtransit.android.commons.provider.gtfs.agencyTag
 import org.mtransit.android.commons.provider.gtfs.getTargetUUIDs
 import org.mtransit.android.commons.provider.gtfs.getTripIds
-import org.mtransit.android.commons.provider.gtfs.getTrips
 import org.mtransit.android.commons.provider.gtfs.ignoreDirection
 import org.mtransit.android.commons.provider.gtfs.makeRequest
 import org.mtransit.android.commons.provider.gtfs.parseRouteId
 import org.mtransit.android.commons.provider.gtfs.parseTripId
 import org.mtransit.android.commons.provider.gtfs.setTripIdsOutOfSync
-import org.mtransit.android.commons.provider.gtfs.targetAuthority
 import org.mtransit.android.commons.provider.vehiclelocations.VehicleLocationProvider.Companion.getCachedVehicleLocationsS
 import org.mtransit.android.commons.provider.vehiclelocations.model.VehicleLocation
 import org.mtransit.android.commons.secsToInstant
@@ -136,9 +134,7 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
         tripIds: List<String>?,
         getCachedVehicleLocations: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<VehicleLocation>?,
     ) = buildList {
-        (
-                getCachedVehicleLocations(targetUUIDs.keys, tripIds)?.takeIf { it.isNotEmpty() }
-                )
+        getCachedVehicleLocations(targetUUIDs.keys, tripIds)?.takeIf { it.isNotEmpty() }
             ?.let {
                 addAll(it)
             }
@@ -273,7 +269,7 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
     private fun GTFSRealTimeProvider.setTripIdsOutOfSync(vehicleLocations: MutableList<VehicleLocation>) {
         setTripIdsOutOfSync(
             getOneTripId = { vehicleLocations.firstOrNull { it.targetTripId != null }?.targetTripId },
-            saveTripIdsOutOfSync = { context, tripIdsOutOfSync  ->
+            saveTripIdsOutOfSync = { context, tripIdsOutOfSync ->
                 GtfsRealTimeStorage.saveVehicleLocationTripIdsOutOfSync(context, tripIdsOutOfSync)
                 _tripIdsOutOfSync = tripIdsOutOfSync
             }

--- a/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
@@ -1,6 +1,7 @@
 package org.mtransit.android.commons.provider.vehiclelocations
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import org.mtransit.android.commons.Constants
 import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.SecurityUtils
@@ -25,13 +26,14 @@ import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.sortVehicles
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toVehicles
 import org.mtransit.android.commons.provider.gtfs.agencyTag
-import org.mtransit.android.commons.provider.gtfs.getPrimaryTargetUUIDs
 import org.mtransit.android.commons.provider.gtfs.getTargetUUIDs
 import org.mtransit.android.commons.provider.gtfs.getTripIds
+import org.mtransit.android.commons.provider.gtfs.getTrips
 import org.mtransit.android.commons.provider.gtfs.ignoreDirection
 import org.mtransit.android.commons.provider.gtfs.makeRequest
 import org.mtransit.android.commons.provider.gtfs.parseRouteId
 import org.mtransit.android.commons.provider.gtfs.parseTripId
+import org.mtransit.android.commons.provider.gtfs.targetAuthority
 import org.mtransit.android.commons.provider.vehiclelocations.VehicleLocationProvider.Companion.getCachedVehicleLocationsS
 import org.mtransit.android.commons.provider.vehiclelocations.model.VehicleLocation
 import org.mtransit.android.commons.secsToInstant
@@ -83,39 +85,58 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
             this * 2L // fewer calls to Cached API $$
         } else this
 
+    private var _tripIdsOutOfSync: Boolean? = null
+
+    private fun GTFSRealTimeProvider.getTripIdOutOfSync() = _tripIdsOutOfSync
+        ?: context?.let { GtfsRealTimeStorage.getVehicleLocationTripIdsOutOfSync(it, false) }.also {
+            _tripIdsOutOfSync = it
+        }
+
     private const val INCLUDE_AGENCY_TAG = true // some transit agencies only use the trip IDs to target #TransitWindsor
 
     @JvmStatic
     fun GTFSRealTimeProvider.getCached(filter: VehicleLocationProviderContract.Filter) =
-        filter.getTargetUUIDs(this, includeAgencyTag = INCLUDE_AGENCY_TAG)
+        getCached(
+            filter,
+            tripIdsOutOfSync = getTripIdOutOfSync(),
+            getTripIds = { authority, routeId, directionId ->
+                context?.getTripIds(authority, routeId, directionId)
+            },
+            getCachedVehicleLocations = { targetUUIDs, tripIds ->
+                getCachedVehicleLocationsS(targetUUIDs, tripIds)
+            }
+        )
+
+    @VisibleForTesting
+    internal fun GTFSRealTimeProvider.getCached(
+        filter: VehicleLocationProviderContract.Filter,
+        tripIdsOutOfSync: Boolean?,
+        getTripIds: (authority: String, routeId: Long, directionId: Long?) -> List<String>?,
+        getCachedVehicleLocations: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<VehicleLocation>?,
+    ): List<VehicleLocation>? {
+        val tripIdsOutOfSync = tripIdsOutOfSync == true
+        @Suppress("SimplifyBooleanWithConstants")
+        return filter.getTargetUUIDs(this, includeAgencyTag = INCLUDE_AGENCY_TAG && !tripIdsOutOfSync)
             ?.let { targetUUIDs ->
-                val tripIds = filter.targetAuthority?.let { targetAuthority ->
+                val tripIds = if (tripIdsOutOfSync) null
+                else filter.targetAuthority?.let { targetAuthority ->
                     filter.routeId?.let { routeId ->
-                        context?.getTripIds(targetAuthority, routeId, filter.directionId)
+                        getTripIds(targetAuthority, routeId, filter.directionId)
                     }
                 }
                 targetUUIDs to tripIds?.takeIf { it.isNotEmpty() } // no trip IDS == fallback to primary target UUID only
             }?.let { (targetUUIDs, tripIds) ->
-                getCached(
-                    filter = filter,
-                    targetUUIDs = targetUUIDs,
-                    tripIds = tripIds,
-                )
+                getCached(targetUUIDs, tripIds, getCachedVehicleLocations)
             }
+    }
 
-    fun GTFSRealTimeProvider.getCached(filter: VehicleLocationProviderContract.Filter, targetUUIDs: Map<String, String>, tripIds: List<String>?) = buildList {
+    private fun getCached(
+        targetUUIDs: Map<String, String>,
+        tripIds: List<String>?,
+        getCachedVehicleLocations: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<VehicleLocation>?,
+    ) = buildList {
         (
-                // 1 - trip IDs preferred for all result filtered correctly
-                tripIds?.let {
-                    getCachedVehicleLocationsS(targetUUIDs.keys, tripIds = it)
-                }?.takeIf { it.isNotEmpty() }
-                // 2 - fallback to: ignore TRIP IDS (outdated?) and try using primary target UUID only
-                // - only works if Route & Direction! provided
-                // -> can NOT show vehicle in wrong direction
-                    ?: if (ignoreDirection) null
-                    else filter.getPrimaryTargetUUIDs(this@getCached, ignoreDirection = false)?.let { (providerTargetUUID, _) ->
-                        getCachedVehicleLocationsS(setOf(providerTargetUUID), tripIds = null)
-                    }?.takeIf { it.isNotEmpty() }
+                getCachedVehicleLocations(targetUUIDs.keys, tripIds)?.takeIf { it.isNotEmpty() }
                 )
             ?.let {
                 addAll(it)
@@ -244,6 +265,16 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
             MTLog.e(LOG_TAG, e, "INTERNAL ERROR: Unknown Exception")
             return null
         }
+    }
+
+    private fun GTFSRealTimeProvider.setTripIdsOutOfSync(vehicleLocations: MutableList<VehicleLocation>) {
+        val context = context ?: return
+        val rtTripId = vehicleLocations.firstOrNull { it.targetTripId != null }?.targetTripId
+        val tripIdsOutOfSync = rtTripId?.let {
+            context.getTrips(targetAuthority, tripIds = listOf(it))?.size == 0 // no trip ID matches == out-of-sync
+        } ?: false // no real-time trip ID == not out-of-sync
+        GtfsRealTimeStorage.saveVehicleLocationTripIdsOutOfSync(context, tripIdsOutOfSync)
+        _tripIdsOutOfSync = tripIdsOutOfSync
     }
 
     private fun GTFSRealTimeProvider.processVehiclePositions(

--- a/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
@@ -33,6 +33,7 @@ import org.mtransit.android.commons.provider.gtfs.ignoreDirection
 import org.mtransit.android.commons.provider.gtfs.makeRequest
 import org.mtransit.android.commons.provider.gtfs.parseRouteId
 import org.mtransit.android.commons.provider.gtfs.parseTripId
+import org.mtransit.android.commons.provider.gtfs.setTripIdsOutOfSync
 import org.mtransit.android.commons.provider.gtfs.targetAuthority
 import org.mtransit.android.commons.provider.vehiclelocations.VehicleLocationProvider.Companion.getCachedVehicleLocationsS
 import org.mtransit.android.commons.provider.vehiclelocations.model.VehicleLocation
@@ -236,6 +237,7 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
                                 MTLog.d(LOG_TAG, "loadAgencyDataFromWWW() > - new ${vehicleLocation.toStringShort()}.")
                             }
                         }
+                        setTripIdsOutOfSync(vehicleLocations)
                         return vehicleLocations
                     }
 
@@ -268,13 +270,13 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
     }
 
     private fun GTFSRealTimeProvider.setTripIdsOutOfSync(vehicleLocations: MutableList<VehicleLocation>) {
-        val context = context ?: return
-        val rtTripId = vehicleLocations.firstOrNull { it.targetTripId != null }?.targetTripId
-        val tripIdsOutOfSync = rtTripId?.let {
-            context.getTrips(targetAuthority, tripIds = listOf(it))?.size == 0 // no trip ID matches == out-of-sync
-        } ?: false // no real-time trip ID == not out-of-sync
-        GtfsRealTimeStorage.saveVehicleLocationTripIdsOutOfSync(context, tripIdsOutOfSync)
-        _tripIdsOutOfSync = tripIdsOutOfSync
+        setTripIdsOutOfSync(
+            getOneTripId = { vehicleLocations.firstOrNull { it.targetTripId != null }?.targetTripId },
+            saveTripIdsOutOfSync = { context, tripIdsOutOfSync  ->
+                GtfsRealTimeStorage.saveVehicleLocationTripIdsOutOfSync(context, tripIdsOutOfSync)
+                _tripIdsOutOfSync = tripIdsOutOfSync
+            }
+        )
     }
 
     private fun GTFSRealTimeProvider.processVehiclePositions(
@@ -302,7 +304,8 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
         )
     }
 
-    private fun GTFSRealTimeProvider.parseProviderTargetUUID(gVehiclePosition: GVehiclePosition, ignoreDirection: Boolean): String? {
+    @VisibleForTesting
+    internal fun GTFSRealTimeProvider.parseProviderTargetUUID(gVehiclePosition: GVehiclePosition, ignoreDirection: Boolean): String? {
         val gTripDescriptor = gVehiclePosition.optTrip ?: return null
         if (gTripDescriptor.hasModifiedTrip()) {
             MTLog.d(LOG_TAG, "parseTargetUUID() > unhandled modified trip: ${gTripDescriptor.toStringExt()}")

--- a/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
@@ -218,6 +218,7 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
                             if (Constants.DEBUG) {
                                 MTLog.d(LOG_TAG, "loadAgencyDataFromWWW() > GTFS vehicles[${gVehiclePositions.size}]: ")
                             }
+                            val ignoreDirection = ignoreDirection
                             for (gVehiclePosition in gVehiclePositions.sortVehicles()) {
                                 if (Constants.DEBUG) {
                                     MTLog.d(LOG_TAG, "loadAgencyDataFromWWW() > GTFS - ${gVehiclePosition.toStringExt()}.")

--- a/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
@@ -11,7 +11,7 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRoute
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
 import org.mtransit.android.commons.provider.gtfs.GtfsRealTimeStorage
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optBearing
-import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionId
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDirectionIdValid
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optId
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optLabel
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optLatitude
@@ -291,7 +291,7 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
                 -> MTLog.d(LOG_TAG, "parseTargetUUID() > unhandled schedule relationship: ${gTripDescriptor.scheduleRelationship}")
         }
         parseRouteId(gTripDescriptor)?.let { routeId ->
-            gTripDescriptor.optDirectionId?.takeIf { !ignoreDirection }?.let { directionId ->
+            gTripDescriptor.optDirectionIdValid?.takeIf { !ignoreDirection }?.let { directionId ->
                 return getAgencyRouteDirectionTagTargetUUID(agencyTag, routeId, directionId)
             }
             return getAgencyRouteTagTargetUUID(agencyTag, routeId)

--- a/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/VehicleLocationProviderContract.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/VehicleLocationProviderContract.kt
@@ -90,7 +90,7 @@ interface VehicleLocationProviderContract : ProviderContract {
         }
     }
 
-    data class Filter @Discouraged("use from() instead") constructor(
+    data class Filter @Discouraged("use secondary constructor() instead") constructor(
         val authority: String,
         override val poi: POI? = null, // RouteDirectionStop or DefaultPOI
         override val route: Route? = null,
@@ -107,15 +107,15 @@ interface VehicleLocationProviderContract : ProviderContract {
             private set
 
         @SuppressLint("DiscouragedApi")
-        constructor(poi: POI, tripIds: List<String>? = null) :
+        constructor(poi: POI) :
                 this(authority = poi.authority, poi = poi)
 
         @SuppressLint("DiscouragedApi")
-        constructor(route: Route, tripIds: List<String>? = null) :
+        constructor(route: Route) :
                 this(authority = route.authority, route = route)
 
         @SuppressLint("DiscouragedApi")
-        constructor(routeDirection: RouteDirection, tripIds: List<String>? = null) :
+        constructor(routeDirection: RouteDirection) :
                 this(authority = routeDirection.authority, routeDirection = routeDirection)
 
         @Suppress("unused") // main app only

--- a/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
@@ -42,11 +42,11 @@ fun makeRDS(
     false,
 )
 
-fun RouteDirectionStop.getGTFSRTTargetUUID(): String =
+fun RouteDirectionStop.getGTFSRTTargetUUID(ignoreDirection: Boolean = false): String =
     GTFSRealTimeProvider.getAgencyRouteDirectionStopTagTargetUUID(
         authority,
         route.originalIdHash.toString(),
-        direction.originalDirectionIdOrNull,
+        direction.originalDirectionIdOrNull?.takeIf { !ignoreDirection },
         stop.originalIdHashString
     ) ?: GTFSRealTimeProvider.getAgencyRouteStopTagTargetUUID(
         authority,

--- a/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
@@ -1,0 +1,58 @@
+package org.mtransit.android.commons.data
+
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider
+
+fun makeRDS(
+    authority: String = "authority",
+    routeId: Long = 1L,
+    routeOriginalIdHash: Int? = routeId.toString().hashCode(),
+    routeType: Int = 3,
+    originalDirectionId: Int? = 1,
+    directionId: Long = originalDirectionId?.let { routeId * 100L + it } ?: (routeId * 100L + 9L),
+    stopId: Int = 1,
+    stopOriginalIdHash: Int? = stopId.toString().hashCode() // stopId, // "$stopId".hashCode()
+) = RouteDirectionStop(
+    1,
+    Route(
+        authority,
+        routeId,
+        "#$routeId",
+        "route $routeId",
+        "color",
+        routeOriginalIdHash,
+        routeType,
+    ),
+    Direction(
+        authority,
+        directionId,
+        Direction.HEADSIGN_TYPE_STRING,
+        "Head-Sign $originalDirectionId",
+        routeId,
+    ),
+    Stop(
+        stopId,
+        "#$stopId",
+        "Stop #$stopId",
+        1.0,
+        2.0,
+        Accessibility.DEFAULT,
+        stopOriginalIdHash,
+    ),
+    false,
+    false,
+)
+
+fun RouteDirectionStop.getGTFSRTTargetUUID(): String =
+    GTFSRealTimeProvider.getAgencyRouteDirectionStopTagTargetUUID(
+        authority,
+        route.originalIdHash.toString(),
+        direction.originalDirectionIdOrNull,
+        stop.originalIdHashString
+    ) ?: GTFSRealTimeProvider.getAgencyRouteStopTagTargetUUID(
+        authority,
+        route.originalIdHash.toString(),
+        stop.originalIdHashString
+    ) ?: GTFSRealTimeProvider.getAgencyRouteTagTargetUUID(
+        authority,
+        route.originalIdHash.toString()
+    )

--- a/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
@@ -58,9 +58,9 @@ fun RouteDirection.getGTFSRTTargetUUID(): String =
         route.originalIdHash.toString()
     )
 
-
-fun RouteDirectionStop.getGTFSRTTargetUUID(): String =
-    GTFSRealTimeProvider.getAgencyRouteDirectionStopTagTargetUUID(
+fun RouteDirectionStop.getGTFSRTTargetUUID(includeStopTags: Boolean): String =
+    if (!includeStopTags) this.toRouteDirection().getGTFSRTTargetUUID()
+    else GTFSRealTimeProvider.getAgencyRouteDirectionStopTagTargetUUID(
         authority,
         route.originalIdHash.toString(),
         direction.originalDirectionIdOrNull,

--- a/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/data/RouteDirectionStopTestFixtures.kt
@@ -42,11 +42,28 @@ fun makeRDS(
     false,
 )
 
-fun RouteDirectionStop.getGTFSRTTargetUUID(ignoreDirection: Boolean = false): String =
+fun Route.getGTFSRTTargetUUID(): String =
+    GTFSRealTimeProvider.getAgencyRouteTagTargetUUID(
+        authority,
+        originalIdHash.toString()
+    )
+
+fun RouteDirection.getGTFSRTTargetUUID(): String =
+    GTFSRealTimeProvider.getAgencyRouteDirectionTagTargetUUID(
+        authority,
+        route.originalIdHash.toString(),
+        direction.originalDirectionIdOrNull,
+    ) ?: GTFSRealTimeProvider.getAgencyRouteTagTargetUUID(
+        authority,
+        route.originalIdHash.toString()
+    )
+
+
+fun RouteDirectionStop.getGTFSRTTargetUUID(): String =
     GTFSRealTimeProvider.getAgencyRouteDirectionStopTagTargetUUID(
         authority,
         route.originalIdHash.toString(),
-        direction.originalDirectionIdOrNull?.takeIf { !ignoreDirection },
+        direction.originalDirectionIdOrNull,
         stop.originalIdHashString
     ) ?: GTFSRealTimeProvider.getAgencyRouteStopTagTargetUUID(
         authority,

--- a/src/test/java/org/mtransit/android/commons/data/ServiceUpdateTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/data/ServiceUpdateTestFixtures.kt
@@ -1,0 +1,53 @@
+package org.mtransit.android.commons.data
+
+import org.mtransit.android.commons.TimeUtilsK
+import org.mtransit.android.commons.toMillis
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+fun makeServiceUpdate(
+    optId: Int? = null,
+    targetUUID: String = "uuid",
+    targetTripId: String? = null,
+    lastUpdate: Instant = TimeUtilsK.currentInstant(),
+    maxValidity: Duration = 1.hours,
+    text: String = "The text",
+    optTextHTML: String? = null,
+    severity: Int = ServiceUpdate.SEVERITY_NONE,
+    noService: Boolean? = null,
+    sourceId: String = "source_id",
+    sourceLabel: String = "example.org",
+    originalId: String? = null,
+    language: String = "en"
+) = makeServiceUpdate(
+    optId = optId,
+    targetUUID = targetUUID,
+    targetTripId = targetTripId,
+    lastUpdateMs = lastUpdate.toMillis(),
+    maxValidityMs = maxValidity.inWholeMilliseconds,
+    text = text,
+    optTextHTML = optTextHTML,
+    severity = severity,
+    noService = noService,
+    sourceId = sourceId,
+    sourceLabel = sourceLabel,
+    originalId = originalId,
+    language = language,
+)
+
+fun ServiceUpdate.clone() = makeServiceUpdate(
+    optId = id,
+    targetUUID = targetUUID,
+    targetTripId = targetTripId,
+    lastUpdateMs = lastUpdateInMs,
+    maxValidityMs = maxValidityInMs,
+    text = text,
+    optTextHTML = textHTML,
+    severity = severity,
+    noService = isNoService,
+    sourceId = sourceId,
+    sourceLabel = sourceLabel,
+    originalId = originalId,
+    language = language
+)

--- a/src/test/java/org/mtransit/android/commons/provider/GTFSRealTimeProviderTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/GTFSRealTimeProviderTestFixtures.kt
@@ -1,0 +1,12 @@
+package org.mtransit.android.commons.provider
+
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.mtransit.android.commons.data.RouteDirectionStop
+
+fun GTFSRealTimeProvider.setupProviderForRDS(rds: RouteDirectionStop) {
+    whenever { getRouteTag(eq(rds.route)) } doReturn rds.route.originalIdHash.toString()
+    whenever { getDirectionTag(eq(rds.direction)) } doReturn rds.direction.originalDirectionIdOrNull
+    whenever { getStopTag(eq(rds.stop)) } doReturn rds.stop.originalIdHashString
+}

--- a/src/test/java/org/mtransit/android/commons/provider/GTFSRealTimeProviderTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/GTFSRealTimeProviderTestFixtures.kt
@@ -10,3 +10,5 @@ fun GTFSRealTimeProvider.setupProviderForRDS(rds: RouteDirectionStop) {
     whenever { getDirectionTag(eq(rds.direction)) } doReturn rds.direction.originalDirectionIdOrNull
     whenever { getStopTag(eq(rds.stop)) } doReturn rds.stop.originalIdHashString
 }
+
+fun stringIdToHash(originalId: String) = originalId.hashCode().toString()

--- a/src/test/java/org/mtransit/android/commons/provider/GTFSRealTimeProviderTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/GTFSRealTimeProviderTestFixtures.kt
@@ -6,9 +6,9 @@ import org.mockito.kotlin.whenever
 import org.mtransit.android.commons.data.RouteDirectionStop
 
 fun GTFSRealTimeProvider.setupProviderForRDS(rds: RouteDirectionStop) {
-    whenever { getRouteTag(eq(rds.route)) } doReturn rds.route.originalIdHash.toString()
-    whenever { getDirectionTag(eq(rds.direction)) } doReturn rds.direction.originalDirectionIdOrNull
-    whenever { getStopTag(eq(rds.stop)) } doReturn rds.stop.originalIdHashString
+    whenever(getRouteTag(eq(rds.route))) doReturn rds.route.originalIdHash.toString()
+    whenever(getDirectionTag(eq(rds.direction))) doReturn rds.direction.originalDirectionIdOrNull
+    whenever(getStopTag(eq(rds.stop))) doReturn rds.stop.originalIdHashString
 }
 
 fun stringIdToHash(originalId: String) = originalId.hashCode().toString()

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -12,6 +12,7 @@ import org.mtransit.android.commons.data.clone
 import org.mtransit.android.commons.data.getGTFSRTTargetUUID
 import org.mtransit.android.commons.data.makeRDS
 import org.mtransit.android.commons.data.makeServiceUpdate
+import org.mtransit.android.commons.data.toRouteDirection
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteDirectionStopTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteDirectionTagTargetUUID
@@ -20,7 +21,6 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRoute
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteTypeTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyStopTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
-import org.mtransit.android.commons.provider.gtfs.getTargetUUIDs
 import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.getCached
 import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID
 import org.mtransit.commons.CommonsApp
@@ -60,9 +60,11 @@ class GTFSRealTimeServiceAlertsProviderTest {
         val cachedServiceUpdates = buildList {
             add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId10", text = "Text 10"))
             add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId11", text = "Text 11"))
-            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(ignoreDirection = true), targetTripId = "tripId12", text = "Text 12"))
+            add(makeServiceUpdate(targetUUID = rds1.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = "tripId12", text = "Text 12"))
+            add(makeServiceUpdate(targetUUID = rds1.route.getGTFSRTTargetUUID(), targetTripId = "tripId13", text = "Text 13"))
             add(makeServiceUpdate(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = null, text = "Text 00"))
         }
+        val staticTripIds = cachedServiceUpdates.mapNotNull { it.targetTripId }.toSet() + "tripId22"
         val getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>? = { targetUUIDs, tripIds ->
             cachedServiceUpdates.filter { serviceUpdate ->
                 targetUUIDs.contains(serviceUpdate.targetUUID)
@@ -71,11 +73,11 @@ class GTFSRealTimeServiceAlertsProviderTest {
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds1),
-            targetUUIDs = rds1.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
-            tripIds = listOf("tripId10"),
+            getTripIds = { _, _, _ -> listOf("tripId10") },
             getCachedServiceUpdates = getCachedServiceUpdates,
-            ignoreDirection = false
+            tripIdsOutOfSync = !staticTripIds.contains("tripId10"),
         ).let { result ->
+            assertNotNull(result)
             assertEquals(2, result.size)
             assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
                 assertEquals(rds1.uuid, it.targetUUID)
@@ -88,14 +90,14 @@ class GTFSRealTimeServiceAlertsProviderTest {
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds1),
-            targetUUIDs = rds1.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
-            tripIds = listOf("tripId12"),
+            getTripIds = { _, _, _ -> listOf("tripId12") },
             getCachedServiceUpdates = getCachedServiceUpdates,
-            ignoreDirection = true
+            tripIdsOutOfSync = !staticTripIds.contains("tripId12"),
         ).let { result ->
+            assertNotNull(result)
             assertEquals(2, result.size)
             assertNotNull(result.singleOrNull { it.targetTripId == "tripId12" }) {
-                assertEquals(rds1.uuid, it.targetUUID)
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
                 assertEquals("Text 12", it.text)
             }
             assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
@@ -105,53 +107,36 @@ class GTFSRealTimeServiceAlertsProviderTest {
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds1),
-            targetUUIDs = rds1.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
-            tripIds = listOf("tripId177777"), // out-of-sync (static!=real-time)
+            getTripIds = { _, _, _ -> listOf("tripId177777") },
             getCachedServiceUpdates = getCachedServiceUpdates,
-            ignoreDirection = false
+            tripIdsOutOfSync = !staticTripIds.contains("tripId177777"),
         ).let { result ->
-            if (true) {
-                assertEquals(1, result.size)
-                assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
-                    assertNull(it.targetTripId)
-                    assertEquals("Text 00", it.text)
-                }
-            } else { // FIXME
-                assertEquals(3, result.size)
-                assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
-                    assertEquals(rds1.uuid, it.targetUUID)
-                    assertEquals("Text 10", it.text)
-                }
-                assertNotNull(result.singleOrNull { it.targetTripId == "tripId11" }) {
-                    assertEquals(rds1.uuid, it.targetUUID)
-                    assertEquals("Text 11", it.text)
-                }
-                assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
-                    assertNull(it.targetTripId)
-                    assertEquals("Text 00", it.text)
-                }
+            assertNotNull(result)
+            assertEquals(4, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
+                assertEquals(rds1.uuid, it.targetUUID)
+                assertEquals("Text 10", it.text)
             }
-        }
-        gtfsRealTimeProvider.getCached(
-            filter = ServiceUpdateProviderContract.Filter(rds1),
-            targetUUIDs = rds1.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
-            tripIds = listOf("tripId177777"), // out-of-sync (static!=real-time)
-            getCachedServiceUpdates = getCachedServiceUpdates,
-            ignoreDirection = true
-        ).let { result ->
-            assertEquals(1, result.size)
-            assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
-                assertNull(it.targetTripId)
-                assertEquals("Text 00", it.text)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId11" }) {
+                assertEquals(rds1.uuid, it.targetUUID)
+                assertEquals("Text 11", it.text)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId12" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("Text 12", it.text)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId13" }) {
+                assertEquals(rds1.route.uuid, it.targetUUID)
+                assertEquals("Text 13", it.text)
             }
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds2),
-            targetUUIDs = rds2.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
-            tripIds = listOf("tripId22"),
+            getTripIds = { _, _, _ -> listOf("tripId22") },
             getCachedServiceUpdates = getCachedServiceUpdates,
-            ignoreDirection = false
+            tripIdsOutOfSync = !staticTripIds.contains("tripId22"),
         ).let { result ->
+            assertNotNull(result)
             assertEquals(1, result.size)
             assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
                 assertNull(it.targetTripId)

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -57,12 +57,20 @@ class GTFSRealTimeServiceAlertsProviderTest {
             stopId = 20,
         )
         gtfsRealTimeProvider.setupProviderForRDS(rds2)
+        val rds3 = makeRDS(
+            authority = "static_agency_id",
+            routeId = 3L,
+            originalDirectionId = 0,
+            stopId = 30,
+        )
+        gtfsRealTimeProvider.setupProviderForRDS(rds3)
         val cachedServiceUpdates = buildList {
             add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(true), targetTripId = "tripId10", text = "Text 10"))
             add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(true), targetTripId = "tripId11", text = "Text 11"))
             add(makeServiceUpdate(targetUUID = rds1.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = "tripId12", text = "Text 12"))
             add(makeServiceUpdate(targetUUID = rds1.route.getGTFSRTTargetUUID(), targetTripId = "tripId13", text = "Text 13"))
             add(makeServiceUpdate(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = null, text = "Text 00"))
+            add(makeServiceUpdate(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = "tripId01", text = "Text 01"))
         }
         val staticTripIds = (cachedServiceUpdates.mapNotNull { it.targetTripId } + "tripId22").toSet()
         val getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>? = { targetUUIDs, tripIds ->
@@ -108,11 +116,28 @@ class GTFSRealTimeServiceAlertsProviderTest {
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds1),
             getCachedServiceUpdates = getCachedServiceUpdates,
+            getTripIds = { _, _, _ -> listOf("tripId01") },
+            tripIdsOutOfSync = !staticTripIds.contains("tripId01"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(2, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId01" }) {
+                assertEquals("static_agency_id", it.targetUUID)
+                assertEquals("Text 01", it.text)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == null }) {
+                assertEquals("static_agency_id", it.targetUUID)
+                assertEquals("Text 00", it.text)
+            }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = ServiceUpdateProviderContract.Filter(rds1),
+            getCachedServiceUpdates = getCachedServiceUpdates,
             getTripIds = { _, _, _ -> fail("should not call since out of sync for tripId177777") },
             tripIdsOutOfSync = !staticTripIds.contains("tripId177777"),
         ).let { result ->
             assertNotNull(result)
-            assertEquals(4, result.size)
+            assertEquals(5, result.size)
             assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
                 assertEquals(rds1.uuid, it.targetUUID)
                 assertEquals("Text 10", it.text)
@@ -129,12 +154,42 @@ class GTFSRealTimeServiceAlertsProviderTest {
                 assertEquals(rds1.route.uuid, it.targetUUID)
                 assertEquals("Text 13", it.text)
             }
+            assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                assertNull(it.targetTripId)
+                assertEquals("Text 00", it.text)
+            }
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds2),
             getCachedServiceUpdates = getCachedServiceUpdates,
             getTripIds = { _, _, _ -> listOf("tripId22") },
             tripIdsOutOfSync = !staticTripIds.contains("tripId22"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(1, result.size)
+            assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                assertNull(it.targetTripId)
+                assertEquals("Text 00", it.text)
+            }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = ServiceUpdateProviderContract.Filter(rds3),
+            getCachedServiceUpdates = getCachedServiceUpdates,
+            getTripIds = { _, _, _ -> listOf("tripId33") },
+            tripIdsOutOfSync = false,
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(1, result.size)
+            assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                assertNull(it.targetTripId)
+                assertEquals("Text 00", it.text)
+            }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = ServiceUpdateProviderContract.Filter(rds3),
+            getCachedServiceUpdates = getCachedServiceUpdates,
+            getTripIds = { _, _, _ -> listOf("tripId33") },
+            tripIdsOutOfSync = true,
         ).let { result ->
             assertNotNull(result)
             assertEquals(1, result.size)

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -58,11 +58,16 @@ class GTFSRealTimeServiceAlertsProviderTest {
         )
         setupProviderForRDS(rds2)
         val cachedServiceUpdates = buildList {
-            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId10"))
-            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId11"))
+            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId10", text = "Text 10"))
+            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId11", text = "Text 11"))
+            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(ignoreDirection = true), targetTripId = "tripId12", text = "Text 12"))
+            add(makeServiceUpdate(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = null, text = "Text 00"))
         }
         val getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>? = { targetUUIDs, tripIds ->
-            cachedServiceUpdates.filter { targetUUIDs.contains(it.targetUUID) && tripIds?.contains(it.targetTripId) != false }.map { it.clone() }
+            cachedServiceUpdates.filter { serviceUpdate ->
+                targetUUIDs.contains(serviceUpdate.targetUUID)
+                        && serviceUpdate.targetTripId?.let { tripIds?.contains(it) } != false // ignore if target tripID or local trip ID null
+            }.map { it.clone() }
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds1),
@@ -71,9 +76,31 @@ class GTFSRealTimeServiceAlertsProviderTest {
             getCachedServiceUpdates = getCachedServiceUpdates,
             ignoreDirection = false
         ).let { result ->
-            assertEquals(1, result.size)
+            assertEquals(2, result.size)
             assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
                 assertEquals(rds1.uuid, it.targetUUID)
+                assertEquals("Text 10", it.text)
+            }
+            assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                assertNull(it.targetTripId)
+                assertEquals("Text 00", it.text)
+            }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = ServiceUpdateProviderContract.Filter(rds1),
+            targetUUIDs = rds1.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
+            tripIds = listOf("tripId12"),
+            getCachedServiceUpdates = getCachedServiceUpdates,
+            ignoreDirection = true
+        ).let { result ->
+            assertEquals(2, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId12" }) {
+                assertEquals(rds1.uuid, it.targetUUID)
+                assertEquals("Text 12", it.text)
+            }
+            assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                assertNull(it.targetTripId)
+                assertEquals("Text 00", it.text)
             }
         }
         gtfsRealTimeProvider.getCached(
@@ -83,12 +110,26 @@ class GTFSRealTimeServiceAlertsProviderTest {
             getCachedServiceUpdates = getCachedServiceUpdates,
             ignoreDirection = false
         ).let { result ->
-            assertEquals(2, result.size)
-            assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
-                assertEquals(rds1.uuid, it.targetUUID)
-            }
-            assertNotNull(result.singleOrNull { it.targetTripId == "tripId11" }) {
-                assertEquals(rds1.uuid, it.targetUUID)
+            if (true) {
+                assertEquals(1, result.size)
+                assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                    assertNull(it.targetTripId)
+                    assertEquals("Text 00", it.text)
+                }
+            } else { // FIXME
+                assertEquals(3, result.size)
+                assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
+                    assertEquals(rds1.uuid, it.targetUUID)
+                    assertEquals("Text 10", it.text)
+                }
+                assertNotNull(result.singleOrNull { it.targetTripId == "tripId11" }) {
+                    assertEquals(rds1.uuid, it.targetUUID)
+                    assertEquals("Text 11", it.text)
+                }
+                assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                    assertNull(it.targetTripId)
+                    assertEquals("Text 00", it.text)
+                }
             }
         }
         gtfsRealTimeProvider.getCached(
@@ -98,7 +139,11 @@ class GTFSRealTimeServiceAlertsProviderTest {
             getCachedServiceUpdates = getCachedServiceUpdates,
             ignoreDirection = true
         ).let { result ->
-            assertEquals(0, result.size)
+            assertEquals(1, result.size)
+            assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                assertNull(it.targetTripId)
+                assertEquals("Text 00", it.text)
+            }
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds2),
@@ -107,7 +152,11 @@ class GTFSRealTimeServiceAlertsProviderTest {
             getCachedServiceUpdates = getCachedServiceUpdates,
             ignoreDirection = false
         ).let { result ->
-            assertEquals(0, result.size)
+            assertEquals(1, result.size)
+            assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
+                assertNull(it.targetTripId)
+                assertEquals("Text 00", it.text)
+            }
         }
     }
 

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -71,8 +71,10 @@ class GTFSRealTimeServiceAlertsProviderTest {
             add(makeServiceUpdate(targetUUID = rds1.route.getGTFSRTTargetUUID(), targetTripId = "tripId13", text = "Text 13"))
             add(makeServiceUpdate(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = null, text = "Text 00"))
             add(makeServiceUpdate(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = "tripId01", text = "Text 01"))
+            add(makeServiceUpdate(targetUUID = rds3.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = "tripId30", text = "Text 30"))
+            add(makeServiceUpdate(targetUUID = rds3.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = null, text = "Text 31"))
         }
-        val staticTripIds = (cachedServiceUpdates.mapNotNull { it.targetTripId } + "tripId22").toSet()
+        val staticTripIds = (cachedServiceUpdates.mapNotNull { it.targetTripId } + "tripId22" + "tripId31").toSet()
         val getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>? = { targetUUIDs, tripIds ->
             cachedServiceUpdates.filter { serviceUpdate ->
                 targetUUIDs.contains(serviceUpdate.targetUUID)
@@ -175,11 +177,19 @@ class GTFSRealTimeServiceAlertsProviderTest {
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds3),
             getCachedServiceUpdates = getCachedServiceUpdates,
-            getTripIds = { _, _, _ -> listOf("tripId33") },
+            getTripIds = { _, _, _ -> listOf("tripId30", "tripId31") },
             tripIdsOutOfSync = false,
         ).let { result ->
             assertNotNull(result)
-            assertEquals(1, result.size)
+            assertEquals(3, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId30" }) {
+                assertEquals(rds3.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("Text 30", it.text)
+            }
+            assertNotNull(result.singleOrNull { it.text == "Text 31" }) {
+                assertEquals(rds3.toRouteDirection().uuid, it.targetUUID)
+                assertNull(it.targetTripId)
+            }
             assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
                 assertNull(it.targetTripId)
                 assertEquals("Text 00", it.text)
@@ -188,11 +198,19 @@ class GTFSRealTimeServiceAlertsProviderTest {
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds3),
             getCachedServiceUpdates = getCachedServiceUpdates,
-            getTripIds = { _, _, _ -> listOf("tripId33") },
+            getTripIds = { _, _, _ -> listOf("tripId30", "tripId31") },
             tripIdsOutOfSync = true,
         ).let { result ->
             assertNotNull(result)
-            assertEquals(1, result.size)
+            assertEquals(3, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId30" }) {
+                assertEquals(rds3.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("Text 30", it.text)
+            }
+            assertNotNull(result.singleOrNull { it.text == "Text 31" }) {
+                assertEquals(rds3.toRouteDirection().uuid, it.targetUUID)
+                assertNull(it.targetTripId)
+            }
             assertNotNull(result.singleOrNull { it.targetUUID == "static_agency_id" }) {
                 assertNull(it.targetTripId)
                 assertEquals("Text 00", it.text)

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -3,10 +3,7 @@ package org.mtransit.android.commons.provider.serviceupdate
 import com.google.transit.realtime.entitySelector
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import org.mtransit.android.commons.data.RouteDirectionStop
 import org.mtransit.android.commons.data.ServiceUpdate
 import org.mtransit.android.commons.data.clone
 import org.mtransit.android.commons.data.getGTFSRTTargetUUID
@@ -23,12 +20,14 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyStopT
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
 import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.getCached
 import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID
+import org.mtransit.android.commons.provider.setupProviderForRDS
 import org.mtransit.commons.CommonsApp
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.fail
 
 class GTFSRealTimeServiceAlertsProviderTest {
 
@@ -42,29 +41,29 @@ class GTFSRealTimeServiceAlertsProviderTest {
     }
 
     @Test
-    fun test_getCached() {
+    fun test_getCached() { // ignoreDirection handled during cache creation
         val rds1 = makeRDS(
             authority = "static_agency_id",
             routeId = 1L,
             originalDirectionId = 1,
             stopId = 10,
         )
-        setupProviderForRDS(rds1)
+        gtfsRealTimeProvider.setupProviderForRDS(rds1)
         val rds2 = makeRDS(
             authority = "static_agency_id",
             routeId = 2L,
             originalDirectionId = 0,
             stopId = 20,
         )
-        setupProviderForRDS(rds2)
+        gtfsRealTimeProvider.setupProviderForRDS(rds2)
         val cachedServiceUpdates = buildList {
-            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId10", text = "Text 10"))
-            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId11", text = "Text 11"))
+            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(true), targetTripId = "tripId10", text = "Text 10"))
+            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(true), targetTripId = "tripId11", text = "Text 11"))
             add(makeServiceUpdate(targetUUID = rds1.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = "tripId12", text = "Text 12"))
             add(makeServiceUpdate(targetUUID = rds1.route.getGTFSRTTargetUUID(), targetTripId = "tripId13", text = "Text 13"))
             add(makeServiceUpdate(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = null, text = "Text 00"))
         }
-        val staticTripIds = cachedServiceUpdates.mapNotNull { it.targetTripId }.toSet() + "tripId22"
+        val staticTripIds = (cachedServiceUpdates.mapNotNull { it.targetTripId } + "tripId22").toSet()
         val getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>? = { targetUUIDs, tripIds ->
             cachedServiceUpdates.filter { serviceUpdate ->
                 targetUUIDs.contains(serviceUpdate.targetUUID)
@@ -73,8 +72,8 @@ class GTFSRealTimeServiceAlertsProviderTest {
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds1),
-            getTripIds = { _, _, _ -> listOf("tripId10") },
             getCachedServiceUpdates = getCachedServiceUpdates,
+            getTripIds = { _, _, _ -> listOf("tripId10") },
             tripIdsOutOfSync = !staticTripIds.contains("tripId10"),
         ).let { result ->
             assertNotNull(result)
@@ -90,8 +89,8 @@ class GTFSRealTimeServiceAlertsProviderTest {
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds1),
-            getTripIds = { _, _, _ -> listOf("tripId12") },
             getCachedServiceUpdates = getCachedServiceUpdates,
+            getTripIds = { _, _, _ -> listOf("tripId12") },
             tripIdsOutOfSync = !staticTripIds.contains("tripId12"),
         ).let { result ->
             assertNotNull(result)
@@ -107,8 +106,8 @@ class GTFSRealTimeServiceAlertsProviderTest {
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds1),
-            getTripIds = { _, _, _ -> listOf("tripId177777") },
             getCachedServiceUpdates = getCachedServiceUpdates,
+            getTripIds = { _, _, _ -> fail("should not call since out of sync for tripId177777") },
             tripIdsOutOfSync = !staticTripIds.contains("tripId177777"),
         ).let { result ->
             assertNotNull(result)
@@ -132,8 +131,8 @@ class GTFSRealTimeServiceAlertsProviderTest {
         }
         gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds2),
-            getTripIds = { _, _, _ -> listOf("tripId22") },
             getCachedServiceUpdates = getCachedServiceUpdates,
+            getTripIds = { _, _, _ -> listOf("tripId22") },
             tripIdsOutOfSync = !staticTripIds.contains("tripId22"),
         ).let { result ->
             assertNotNull(result)
@@ -143,12 +142,6 @@ class GTFSRealTimeServiceAlertsProviderTest {
                 assertEquals("Text 00", it.text)
             }
         }
-    }
-
-    private fun setupProviderForRDS(rds: RouteDirectionStop) {
-        whenever { gtfsRealTimeProvider.getRouteTag(eq(rds.route)) } doReturn rds.route.originalIdHash.toString()
-        whenever { gtfsRealTimeProvider.getDirectionTag(eq(rds.direction)) } doReturn rds.direction.originalDirectionIdOrNull
-        whenever { gtfsRealTimeProvider.getStopTag(eq(rds.stop)) } doReturn rds.stop.originalIdHashString
     }
 
     @Test

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -21,6 +21,7 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTa
 import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.getCached
 import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID
 import org.mtransit.android.commons.provider.setupProviderForRDS
+import org.mtransit.android.commons.provider.stringIdToHash
 import org.mtransit.commons.CommonsApp
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -249,7 +250,4 @@ class GTFSRealTimeServiceAlertsProviderTest {
             assertEquals(getAgencyRouteTypeTagTargetUUID("static_agency_id", 3), result)
         }
     }
-
-    private fun stringIdToHash(originalId: String) = originalId.hashCode().toString()
-
 }

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -1,0 +1,141 @@
+package org.mtransit.android.commons.provider.serviceupdate
+
+import com.google.transit.realtime.entitySelector
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteDirectionStopTagTargetUUID
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteDirectionTagTargetUUID
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteStopTagTargetUUID
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteTagTargetUUID
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteTypeTagTargetUUID
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyStopTagTargetUUID
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
+import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID
+import org.mtransit.commons.CommonsApp
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GTFSRealTimeServiceAlertsProviderTest {
+
+    private val gtfsRealTimeProvider: GTFSRealTimeProvider = mock {
+        on { getAgencyTag(anyOrNull()) } doReturn "static_agency_id"
+    }
+
+    @BeforeTest
+    fun setUp() {
+        CommonsApp.setup(false)
+    }
+
+    @Test
+    fun test_parseProviderTargetUUID() {
+        // EMPTY
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {},
+            ignoreDirection = false
+        ).let { result ->
+            assertNull(result)
+        }
+        // AGENCY only
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                agencyId = "agency_id"
+            },
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(getAgencyTagTargetUUID("static_agency_id"), result)
+        }
+        // ROUTE
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                routeId = "route_id"
+            },
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(getAgencyRouteTagTargetUUID("static_agency_id", stringIdToHash("route_id")), result)
+        }
+        // ROUTE + DIRECTION
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                routeId = "route_id"
+                directionId = 0
+            },
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(getAgencyRouteDirectionTagTargetUUID("static_agency_id", stringIdToHash("route_id"), 0), result)
+        }
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                routeId = "route_id"
+                directionId = 777777777 // INVALID!
+            },
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(getAgencyRouteTagTargetUUID("static_agency_id", stringIdToHash("route_id")), result)
+        }
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                routeId = "route_id"
+                directionId = 0
+            },
+            ignoreDirection = true
+        ).let { result ->
+            assertEquals(getAgencyRouteTagTargetUUID("static_agency_id", stringIdToHash("route_id")), result)
+        }
+        // ROUTE + DIRECTION + STOP
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                routeId = "route_id"
+                directionId = 0
+                stopId = "stop_id"
+            },
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(getAgencyRouteDirectionStopTagTargetUUID("static_agency_id", stringIdToHash("route_id"), 0, stringIdToHash("stop_id")), result)
+        }
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                routeId = "route_id"
+                directionId = 0
+                stopId = "stop_id"
+            },
+            ignoreDirection = true
+        ).let { result ->
+            assertEquals(getAgencyRouteStopTagTargetUUID("static_agency_id", stringIdToHash("route_id"), stringIdToHash("stop_id")), result)
+        }
+        // ROUTE + STOP
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                routeId = "route_id"
+                stopId = "stop_id"
+            },
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(getAgencyRouteStopTagTargetUUID("static_agency_id", stringIdToHash("route_id"), stringIdToHash("stop_id")), result)
+        }
+        // STOP only
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                stopId = "stop_id"
+            },
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(getAgencyStopTagTargetUUID("static_agency_id", stringIdToHash("stop_id")), result)
+        }
+        // ROUTE TYPE
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gEntitySelector = entitySelector {
+                routeType = 3 // bus
+            },
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(getAgencyRouteTypeTagTargetUUID("static_agency_id", 3), result)
+        }
+    }
+
+    private fun stringIdToHash(originalId: String) = originalId.hashCode().toString()
+
+}

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -92,6 +92,15 @@ class GTFSRealTimeServiceAlertsProviderTest {
             }
         }
         gtfsRealTimeProvider.getCached(
+            filter = ServiceUpdateProviderContract.Filter(rds1),
+            targetUUIDs = rds1.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
+            tripIds = listOf("tripId177777"), // out-of-sync (static!=real-time)
+            getCachedServiceUpdates = getCachedServiceUpdates,
+            ignoreDirection = true
+        ).let { result ->
+            assertEquals(0, result.size)
+        }
+        gtfsRealTimeProvider.getCached(
             filter = ServiceUpdateProviderContract.Filter(rds2),
             targetUUIDs = rds2.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
             tripIds = listOf("tripId22"),

--- a/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/serviceupdate/GTFSRealTimeServiceAlertsProviderTest.kt
@@ -3,7 +3,15 @@ package org.mtransit.android.commons.provider.serviceupdate
 import com.google.transit.realtime.entitySelector
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mtransit.android.commons.data.RouteDirectionStop
+import org.mtransit.android.commons.data.ServiceUpdate
+import org.mtransit.android.commons.data.clone
+import org.mtransit.android.commons.data.getGTFSRTTargetUUID
+import org.mtransit.android.commons.data.makeRDS
+import org.mtransit.android.commons.data.makeServiceUpdate
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteDirectionStopTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteDirectionTagTargetUUID
@@ -12,11 +20,14 @@ import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRoute
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteTypeTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyStopTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
+import org.mtransit.android.commons.provider.gtfs.getTargetUUIDs
+import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.getCached
 import org.mtransit.android.commons.provider.serviceupdate.GTFSRealTimeServiceAlertsProvider.parseProviderTargetUUID
 import org.mtransit.commons.CommonsApp
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class GTFSRealTimeServiceAlertsProviderTest {
@@ -28,6 +39,73 @@ class GTFSRealTimeServiceAlertsProviderTest {
     @BeforeTest
     fun setUp() {
         CommonsApp.setup(false)
+    }
+
+    @Test
+    fun test_getCached() {
+        val rds1 = makeRDS(
+            authority = "static_agency_id",
+            routeId = 1L,
+            originalDirectionId = 1,
+            stopId = 10,
+        )
+        setupProviderForRDS(rds1)
+        val rds2 = makeRDS(
+            authority = "static_agency_id",
+            routeId = 2L,
+            originalDirectionId = 0,
+            stopId = 20,
+        )
+        setupProviderForRDS(rds2)
+        val cachedServiceUpdates = buildList {
+            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId10"))
+            add(makeServiceUpdate(targetUUID = rds1.getGTFSRTTargetUUID(), targetTripId = "tripId11"))
+        }
+        val getCachedServiceUpdates: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<ServiceUpdate>? = { targetUUIDs, tripIds ->
+            cachedServiceUpdates.filter { targetUUIDs.contains(it.targetUUID) && tripIds?.contains(it.targetTripId) != false }.map { it.clone() }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = ServiceUpdateProviderContract.Filter(rds1),
+            targetUUIDs = rds1.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
+            tripIds = listOf("tripId10"),
+            getCachedServiceUpdates = getCachedServiceUpdates,
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(1, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
+                assertEquals(rds1.uuid, it.targetUUID)
+            }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = ServiceUpdateProviderContract.Filter(rds1),
+            targetUUIDs = rds1.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
+            tripIds = listOf("tripId177777"), // out-of-sync (static!=real-time)
+            getCachedServiceUpdates = getCachedServiceUpdates,
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(2, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
+                assertEquals(rds1.uuid, it.targetUUID)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId11" }) {
+                assertEquals(rds1.uuid, it.targetUUID)
+            }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = ServiceUpdateProviderContract.Filter(rds2),
+            targetUUIDs = rds2.getTargetUUIDs(gtfsRealTimeProvider, includeAgencyTag = true, includeRouteType = true, includeStopTags = true),
+            tripIds = listOf("tripId22"),
+            getCachedServiceUpdates = getCachedServiceUpdates,
+            ignoreDirection = false
+        ).let { result ->
+            assertEquals(0, result.size)
+        }
+    }
+
+    private fun setupProviderForRDS(rds: RouteDirectionStop) {
+        whenever { gtfsRealTimeProvider.getRouteTag(eq(rds.route)) } doReturn rds.route.originalIdHash.toString()
+        whenever { gtfsRealTimeProvider.getDirectionTag(eq(rds.direction)) } doReturn rds.direction.originalDirectionIdOrNull
+        whenever { gtfsRealTimeProvider.getStopTag(eq(rds.stop)) } doReturn rds.stop.originalIdHashString
     }
 
     @Test

--- a/src/test/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProviderTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.fail
 
 class GTFSRealTimeVehiclePositionsProviderTest {
@@ -52,14 +53,23 @@ class GTFSRealTimeVehiclePositionsProviderTest {
             stopId = 20,
         )
         gtfsRealTimeProvider.setupProviderForRDS(rds2)
+        val rds3 = makeRDS(
+            authority = "static_agency_id",
+            routeId = 3L,
+            originalDirectionId = 0,
+            stopId = 30,
+        )
+        gtfsRealTimeProvider.setupProviderForRDS(rds3)
         val cachedVehicleLocation = buildList {
             add(makeVehicleLocation(targetUUID = rds1.getGTFSRTTargetUUID(false), targetTripId = "tripId10", vehicleId = "vehicleId10"))
             add(makeVehicleLocation(targetUUID = rds1.getGTFSRTTargetUUID(false), targetTripId = "tripId11", vehicleId = "vehicleId11"))
             add(makeVehicleLocation(targetUUID = rds1.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = "tripId12", vehicleId = "vehicleId12"))
             add(makeVehicleLocation(targetUUID = rds1.route.getGTFSRTTargetUUID(), targetTripId = "tripId13", vehicleId = "vehicleId13"))
             add(makeVehicleLocation(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = "tripId00", vehicleId = "vehicleId00"))
+            add(makeVehicleLocation(targetUUID = rds3.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = "tripId30", vehicleId = "vehicleId30"))
+            add(makeVehicleLocation(targetUUID = rds3.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = null, vehicleId = "vehicleId31"))
         }
-        val staticTripIds = (cachedVehicleLocation.mapNotNull { it.targetTripId } + "tripId20").toSet()
+        val staticTripIds = (cachedVehicleLocation.mapNotNull { it.targetTripId } + "tripId20" + "tripId31").toSet()
         val getCachedVehicleLocations: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<VehicleLocation>? = { targetUUIDs, tripIds ->
             cachedVehicleLocation.filter { vehicleLocation ->
                 targetUUIDs.contains(vehicleLocation.targetUUID)
@@ -167,6 +177,23 @@ class GTFSRealTimeVehiclePositionsProviderTest {
         ).let { result ->
             assertNotNull(result)
             assertEquals(0, result.size)
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = VehicleLocationProviderContract.Filter(rds3.toRouteDirection()),
+            getCachedVehicleLocations = getCachedVehicleLocations,
+            getTripIds = { _, _, _ -> listOf("tripId30", "tripId31") },
+            tripIdsOutOfSync = !staticTripIds.contains("tripId30"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(2, result.size)
+            assertNotNull(result.singleOrNull { it.vehicleId == "vehicleId30" }) {
+                assertEquals(rds3.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("tripId30", it.targetTripId)
+            }
+            assertNotNull(result.singleOrNull { it.vehicleId == "vehicleId31" }) {
+                assertEquals(rds3.toRouteDirection().uuid, it.targetUUID)
+                assertNull(it.targetTripId)
+            }
         }
     }
 

--- a/src/test/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProviderTest.kt
@@ -1,0 +1,139 @@
+package org.mtransit.android.commons.provider.vehiclelocations
+
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mtransit.android.commons.data.getGTFSRTTargetUUID
+import org.mtransit.android.commons.data.makeRDS
+import org.mtransit.android.commons.data.toRouteDirection
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
+import org.mtransit.android.commons.provider.setupProviderForRDS
+import org.mtransit.android.commons.provider.vehiclelocations.GTFSRealTimeVehiclePositionsProvider.getCached
+import org.mtransit.android.commons.provider.vehiclelocations.model.VehicleLocation
+import org.mtransit.android.commons.provider.vehiclelocations.model.makeVehicleLocation
+import org.mtransit.commons.CommonsApp
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.fail
+
+class GTFSRealTimeVehiclePositionsProviderTest {
+
+    private val gtfsRealTimeProvider: GTFSRealTimeProvider = mock {
+        on { getAgencyTag(anyOrNull()) } doReturn "static_agency_id"
+    }
+
+    @BeforeTest
+    fun setUp() {
+        CommonsApp.setup(false)
+    }
+
+    @Test
+    fun test() {
+        val rds1 = makeRDS(
+            authority = "static_agency_id",
+            routeId = 1L,
+            originalDirectionId = 1,
+            stopId = 10,
+        )
+        gtfsRealTimeProvider.setupProviderForRDS(rds1)
+        val rds2 = makeRDS(
+            authority = "static_agency_id",
+            routeId = 2L,
+            originalDirectionId = 0,
+            stopId = 20,
+        )
+        gtfsRealTimeProvider.setupProviderForRDS(rds2)
+        val cachedVehicleLocation = buildList {
+            add(makeVehicleLocation(targetUUID = rds1.getGTFSRTTargetUUID(false), targetTripId = "tripId10", vehicleId = "vehicleId10"))
+            add(makeVehicleLocation(targetUUID = rds1.getGTFSRTTargetUUID(false), targetTripId = "tripId11", vehicleId = "vehicleId11"))
+            add(makeVehicleLocation(targetUUID = rds1.toRouteDirection().getGTFSRTTargetUUID(), targetTripId = "tripId12", vehicleId = "vehicleId12"))
+            add(makeVehicleLocation(targetUUID = rds1.route.getGTFSRTTargetUUID(), targetTripId = "tripId13", vehicleId = "vehicleId13"))
+            add(makeVehicleLocation(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = "tripId00", vehicleId = "vehicleId00"))
+        }
+        val staticTripIds = (cachedVehicleLocation.mapNotNull { it.targetTripId } + "tripId22").toSet()
+        val getCachedVehicleLocations: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<VehicleLocation>? = { targetUUIDs, tripIds ->
+            cachedVehicleLocation.filter { vehicleLocation ->
+                targetUUIDs.contains(vehicleLocation.targetUUID)
+                        && vehicleLocation.targetTripId?.let { tripIds?.contains(it) } != false // ignore if target tripID or local trip ID null
+            }.map { it.copy() }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = VehicleLocationProviderContract.Filter(rds1),
+            getCachedVehicleLocations = getCachedVehicleLocations,
+            getTripIds = { _, _, _ -> listOf("tripId10", "tripId11", "tripId12", "tripId13") },
+            tripIdsOutOfSync = !staticTripIds.contains("tripId10"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(4, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId10", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId11" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId11", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId12" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId12", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId13" }) {
+                assertEquals(rds1.route.uuid, it.targetUUID)
+                assertEquals("vehicleId13", it.vehicleId)
+            }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = VehicleLocationProviderContract.Filter(rds1.toRouteDirection()),
+            getCachedVehicleLocations = getCachedVehicleLocations,
+            getTripIds = { _, _, _ -> listOf("tripId10", "tripId11", "tripId12", "tripId13") },
+            tripIdsOutOfSync = !staticTripIds.contains("tripId10"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(4, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId10", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId11" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId11", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId12" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId12", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId13" }) {
+                assertEquals(rds1.route.uuid, it.targetUUID)
+                assertEquals("vehicleId13", it.vehicleId)
+            }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = VehicleLocationProviderContract.Filter(rds1.toRouteDirection()),
+            getCachedVehicleLocations = getCachedVehicleLocations,
+            getTripIds = { _, _, _ -> fail("should not call since out of sync for tripId177777") },
+            tripIdsOutOfSync = !staticTripIds.contains("tripId177777"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(4, result.size)
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId10" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId10", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId11" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId11", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId12" }) {
+                assertEquals(rds1.toRouteDirection().uuid, it.targetUUID)
+                assertEquals("vehicleId12", it.vehicleId)
+            }
+            assertNotNull(result.singleOrNull { it.targetTripId == "tripId13" }) {
+                assertEquals(rds1.route.uuid, it.targetUUID)
+                assertEquals("vehicleId13", it.vehicleId)
+            }
+        }
+    }
+}

--- a/src/test/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProviderTest.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProviderTest.kt
@@ -1,5 +1,7 @@
 package org.mtransit.android.commons.provider.vehiclelocations
 
+import com.google.transit.realtime.tripDescriptor
+import com.google.transit.realtime.vehiclePosition
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -7,9 +9,13 @@ import org.mtransit.android.commons.data.getGTFSRTTargetUUID
 import org.mtransit.android.commons.data.makeRDS
 import org.mtransit.android.commons.data.toRouteDirection
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteDirectionTagTargetUUID
+import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyRouteTagTargetUUID
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider.getAgencyTagTargetUUID
 import org.mtransit.android.commons.provider.setupProviderForRDS
+import org.mtransit.android.commons.provider.stringIdToHash
 import org.mtransit.android.commons.provider.vehiclelocations.GTFSRealTimeVehiclePositionsProvider.getCached
+import org.mtransit.android.commons.provider.vehiclelocations.GTFSRealTimeVehiclePositionsProvider.parseProviderTargetUUID
 import org.mtransit.android.commons.provider.vehiclelocations.model.VehicleLocation
 import org.mtransit.android.commons.provider.vehiclelocations.model.makeVehicleLocation
 import org.mtransit.commons.CommonsApp
@@ -31,7 +37,7 @@ class GTFSRealTimeVehiclePositionsProviderTest {
     }
 
     @Test
-    fun test() {
+    fun test_getCached() {
         val rds1 = makeRDS(
             authority = "static_agency_id",
             routeId = 1L,
@@ -53,7 +59,7 @@ class GTFSRealTimeVehiclePositionsProviderTest {
             add(makeVehicleLocation(targetUUID = rds1.route.getGTFSRTTargetUUID(), targetTripId = "tripId13", vehicleId = "vehicleId13"))
             add(makeVehicleLocation(targetUUID = getAgencyTagTargetUUID("static_agency_id"), targetTripId = "tripId00", vehicleId = "vehicleId00"))
         }
-        val staticTripIds = (cachedVehicleLocation.mapNotNull { it.targetTripId } + "tripId22").toSet()
+        val staticTripIds = (cachedVehicleLocation.mapNotNull { it.targetTripId } + "tripId20").toSet()
         val getCachedVehicleLocations: (targetUUIDs: Collection<String>, tripIds: List<String>?) -> List<VehicleLocation>? = { targetUUIDs, tripIds ->
             cachedVehicleLocation.filter { vehicleLocation ->
                 targetUUIDs.contains(vehicleLocation.targetUUID)
@@ -134,6 +140,88 @@ class GTFSRealTimeVehiclePositionsProviderTest {
                 assertEquals(rds1.route.uuid, it.targetUUID)
                 assertEquals("vehicleId13", it.vehicleId)
             }
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = VehicleLocationProviderContract.Filter(rds2),
+            getCachedVehicleLocations = getCachedVehicleLocations,
+            getTripIds = { _, _, _ -> listOf("tripId20") },
+            tripIdsOutOfSync = !staticTripIds.contains("tripId20"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(0, result.size)
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = VehicleLocationProviderContract.Filter(rds2.toRouteDirection()),
+            getCachedVehicleLocations = getCachedVehicleLocations,
+            getTripIds = { _, _, _ -> listOf("tripId20") },
+            tripIdsOutOfSync = !staticTripIds.contains("tripId20"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(0, result.size)
+        }
+        gtfsRealTimeProvider.getCached(
+            filter = VehicleLocationProviderContract.Filter(rds2.toRouteDirection()),
+            getCachedVehicleLocations = getCachedVehicleLocations,
+            getTripIds = { _, _, _ -> fail("should not call since out of sync for tripId177777") },
+            tripIdsOutOfSync = !staticTripIds.contains("tripId277777"),
+        ).let { result ->
+            assertNotNull(result)
+            assertEquals(0, result.size)
+        }
+    }
+
+    @Test
+    fun test_parseProviderTargetUUID() {
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gVehiclePosition = vehiclePosition {
+                trip = tripDescriptor {}
+            },
+            ignoreDirection = false,
+        ).let { result ->
+            assertEquals(getAgencyTagTargetUUID("static_agency_id"), result)
+        }
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gVehiclePosition = vehiclePosition {
+                trip = tripDescriptor {
+                    routeId = "route_id"
+                }
+            },
+            ignoreDirection = false,
+        ).let { result ->
+            assertEquals(getAgencyRouteTagTargetUUID("static_agency_id", stringIdToHash("route_id")), result)
+        }
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gVehiclePosition = vehiclePosition {
+                trip = tripDescriptor {
+                    routeId = "route_id"
+                    directionId = 0
+                }
+            },
+            ignoreDirection = false,
+        ).let { result ->
+            assertEquals(getAgencyRouteDirectionTagTargetUUID("static_agency_id", stringIdToHash("route_id"), 0), result)
+        }
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gVehiclePosition = vehiclePosition {
+                trip = tripDescriptor {
+                    routeId = "route_id"
+                    directionId = 777777777 // INVALID!
+                }
+            },
+            ignoreDirection = false,
+        ).let { result ->
+            assertEquals(getAgencyRouteTagTargetUUID("static_agency_id", stringIdToHash("route_id")), result)
+        }
+        gtfsRealTimeProvider.parseProviderTargetUUID(
+            gVehiclePosition = vehiclePosition {
+                trip = tripDescriptor {
+                    routeId = "route_id"
+                    directionId = 0
+                }
+            },
+            ignoreDirection = true,
+        ).let { result ->
+            assertEquals(getAgencyRouteTagTargetUUID("static_agency_id", stringIdToHash("route_id")), result)
         }
     }
 }

--- a/src/test/java/org/mtransit/android/commons/provider/vehiclelocations/model/VehicleLocationTestFixtures.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/vehiclelocations/model/VehicleLocationTestFixtures.kt
@@ -1,0 +1,40 @@
+package org.mtransit.android.commons.provider.vehiclelocations.model
+
+import org.mtransit.android.commons.TimeUtilsK
+import org.mtransit.android.commons.toMillis
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+fun makeVehicleLocation(
+    id: Int? = null,
+    authority: String = "authority",
+    targetUUID: String = "uuid",
+    targetTripId: String? = null,
+    lastUpdate: Instant = TimeUtilsK.currentInstant(),
+    maxValidity: Duration = 1.hours,
+    //
+    vehicleId: String? = null,
+    vehicleLabel: String? = null,
+    reportTimestamp: Instant? = lastUpdate - 1.seconds,
+    latitude: Float = 1.0f,
+    longitude: Float = 2.0f,
+    bearingDegrees: Int? = 45,
+    speedMetersPerSecond: Int? = null,
+) = VehicleLocation(
+    id = id,
+    authority = authority,
+    targetUUID = targetUUID,
+    targetTripId = targetTripId,
+    lastUpdateInMs = lastUpdate.toMillis(),
+    maxValidityInMs = maxValidity.inWholeMilliseconds,
+    //
+    vehicleId = vehicleId,
+    vehicleLabel = vehicleLabel,
+    reportTimestamp = reportTimestamp,
+    latitude = latitude,
+    longitude = longitude,
+    bearingDegrees = bearingDegrees,
+    speedMetersPerSecond = speedMetersPerSecond,
+)


### PR DESCRIPTION
- [x] `direction_id` different than 0 or 1? should be always ignored by default
- [x] **Service Alerts**: all? use case covered and tested
- [x] **Vehicle Positions**: all? use cases covered and tested
- [ ] ~**Trip Updates**~ -> #118