### PR TITLE
GTFS-RT providers > handle interrupted I/O exceptions

### DIFF
--- a/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
+++ b/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
@@ -64,6 +64,8 @@ import org.mtransit.commons.FeatureFlags;
 import org.mtransit.commons.GTFSCommons;
 import org.mtransit.commons.SourceUtils;
 
+import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.HttpURLConnection;
 import java.net.SocketException;
 import java.net.UnknownHostException;
@@ -975,7 +977,14 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 			setServiceUpdateLastUpdateCode(567); // SSL certificate not trusted (on this device)
 			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
 			return null;
+		} catch (InterruptedIOException iioe) {
+			MTLog.w(this, iioe, "Connection timeout!");
+			setServiceUpdateLastUpdateCode(567);
+			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
+			return null;
 		} catch (UnknownHostException uhe) {
+			setServiceUpdateLastUpdateCode(567);
+			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
 			if (MTLog.isLoggable(android.util.Log.DEBUG)) {
 				MTLog.w(this, uhe, "No Internet Connection!");
 			} else {
@@ -983,7 +992,14 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 			}
 			return null;
 		} catch (SocketException se) {
+			setServiceUpdateLastUpdateCode(567);
+			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
 			MTLog.w(LOG_TAG, se, "No Internet Connection!");
+			return null;
+		} catch (IOException ioe) {
+			setServiceUpdateLastUpdateCode(567);
+			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
+			MTLog.w(this, ioe, "I/O error!");
 			return null;
 		} catch (Exception e) { // Unknown error
 			MTLog.e(LOG_TAG, e, "INTERNAL ERROR: Unknown Exception");

--- a/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
+++ b/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
@@ -983,23 +983,23 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
 			return null;
 		} catch (UnknownHostException uhe) {
-			setServiceUpdateLastUpdateCode(567);
-			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
 			if (MTLog.isLoggable(android.util.Log.DEBUG)) {
 				MTLog.w(this, uhe, "No Internet Connection!");
 			} else {
 				MTLog.w(this, "No Internet Connection!");
 			}
+			setServiceUpdateLastUpdateCode(567);
+			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
 			return null;
 		} catch (SocketException se) {
+			MTLog.w(LOG_TAG, se, "No Internet Connection!");
 			setServiceUpdateLastUpdateCode(567);
 			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
-			MTLog.w(LOG_TAG, se, "No Internet Connection!");
 			return null;
 		} catch (IOException ioe) {
+			MTLog.w(this, ioe, "I/O error!");
 			setServiceUpdateLastUpdateCode(567);
 			getStorage(context).saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis());
-			MTLog.w(this, ioe, "I/O error!");
 			return null;
 		} catch (Exception e) { // Unknown error
 			MTLog.e(LOG_TAG, e, "INTERNAL ERROR: Unknown Exception");

--- a/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
+++ b/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
@@ -1727,6 +1727,8 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 			db.execSQL(T_GTFS_REAL_TIME_VEHICLE_LOCATION_SQL_CREATE);
 			db.execSQL(T_GTFS_REAL_TIME_SERVICE_UPDATE_SQL_CREATE);
 			storage.saveServiceUpdateLastUpdateMs(null);
+			storage.saveTripUpdateLastUpdateMs(null);
+			storage.saveVehicleLocationLastUpdateMs(null);
 		}
 	}
 }

--- a/src/main/java/org/mtransit/android/commons/provider/ca/info/stm/StmInfoServiceUpdateProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/ca/info/stm/StmInfoServiceUpdateProvider.kt
@@ -1,7 +1,6 @@
 package org.mtransit.android.commons.provider.ca.info.stm
 
 import android.content.Context
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import org.mtransit.android.commons.Constants
 import org.mtransit.android.commons.HtmlUtils
@@ -231,7 +230,7 @@ object StmInfoServiceUpdateProvider : MTLog.Loggable {
             getStorage(context).saveServiceUpdateLastUpdate(TimeUtilsK.currentInstant())
             return null
         } catch (uhe: UnknownHostException) {
-            if (MTLog.isLoggable(Log.DEBUG)) {
+            if (MTLog.isLoggable(android.util.Log.DEBUG)) {
                 MTLog.w(this@StmInfoServiceUpdateProvider, uhe, "No Internet Connection!")
             } else {
                 MTLog.w(this@StmInfoServiceUpdateProvider, "No Internet Connection!")

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealTimeStorage.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealTimeStorage.kt
@@ -35,8 +35,11 @@ class GtfsRealTimeStorage(
         prefLcl.getLong(PREF_KEY_TRIP_UPDATE_LAST_UPDATE_MS, default)
 
     @WorkerThread
-    fun saveTripUpdateLastUpdateMs(lastUpdateInMs: Long) {
-        prefLcl.edit { putLong(PREF_KEY_TRIP_UPDATE_LAST_UPDATE_MS, lastUpdateInMs) }
+    fun saveTripUpdateLastUpdateMs(lastUpdateInMs: Long?) {
+        prefLcl.edit {
+            lastUpdateInMs?.let { putLong(PREF_KEY_TRIP_UPDATE_LAST_UPDATE_MS, it) }
+                ?: remove(PREF_KEY_TRIP_UPDATE_LAST_UPDATE_MS)
+        }
     }
 
     @WorkerThread
@@ -77,8 +80,11 @@ class GtfsRealTimeStorage(
         prefLcl.getLong(PREF_KEY_VEHICLE_LOCATION_LAST_UPDATE_MS, default)
 
     @WorkerThread
-    fun saveVehicleLocationLastUpdateMs(lastUpdateInMs: Long) {
-        prefLcl.edit { putLong(PREF_KEY_VEHICLE_LOCATION_LAST_UPDATE_MS, lastUpdateInMs) }
+    fun saveVehicleLocationLastUpdateMs(lastUpdateInMs: Long?) {
+        prefLcl.edit {
+            lastUpdateInMs?.let { putLong(PREF_KEY_VEHICLE_LOCATION_LAST_UPDATE_MS, it) }
+                ?: remove(PREF_KEY_VEHICLE_LOCATION_LAST_UPDATE_MS)
+        }
     }
 
     @WorkerThread

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -2,7 +2,6 @@ package org.mtransit.android.commons.provider.status
 
 import android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
 import android.content.Context
-import android.util.Log
 import com.google.transit.realtime.headerOrNull
 import org.mtransit.android.commons.Constants
 import org.mtransit.android.commons.MTLog
@@ -37,6 +36,7 @@ import org.mtransit.android.commons.provider.gtfs.storage
 import org.mtransit.commons.SourceUtils
 import java.io.File
 import java.io.IOException
+import java.io.InterruptedIOException
 import java.net.HttpURLConnection
 import java.net.SocketException
 import java.net.UnknownHostException
@@ -46,8 +46,8 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import com.google.transit.realtime.GtfsRealtime.FeedMessage as GFeedMessage
-import com.google.transit.realtime.GtfsRealtime.TripUpdate as GTripUpdate
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship as GTDScheduleRelationship
+import com.google.transit.realtime.GtfsRealtime.TripUpdate as GTripUpdate
 
 object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
 
@@ -453,15 +453,29 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
             storage.saveTripUpdateLastUpdateCode(567) // SSL certificate not trusted (on this device)
             storage.saveTripUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return false
+        } catch (iioe: InterruptedIOException) {
+            MTLog.w(LOG_TAG, iioe, "Connection timeout!")
+            storage.saveTripUpdateLastUpdateCode(567)
+            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            return false
         } catch (uhe: UnknownHostException) {
-            if (MTLog.isLoggable(Log.DEBUG)) {
+            if (MTLog.isLoggable(android.util.Log.DEBUG)) {
                 MTLog.w(LOG_TAG, uhe, "No Internet Connection!")
             } else {
                 MTLog.w(LOG_TAG, "No Internet Connection!")
             }
+            storage.saveTripUpdateLastUpdateCode(567)
+            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return false
         } catch (se: SocketException) {
             MTLog.w(LOG_TAG, se, "No Internet Connection!")
+            storage.saveTripUpdateLastUpdateCode(567)
+            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            return false
+        } catch (ioe: IOException) {
+            MTLog.w(LOG_TAG, ioe, "I/O error!")
+            storage.saveTripUpdateLastUpdateCode(567)
+            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return false
         } catch (e: Exception) { // Unknown error
             MTLog.e(LOG_TAG, e, "INTERNAL ERROR: Unknown Exception")

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -456,7 +456,7 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
         } catch (iioe: InterruptedIOException) {
             MTLog.w(LOG_TAG, iioe, "Connection timeout!")
             storage.saveTripUpdateLastUpdateCode(567)
-            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            storage.saveTripUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return false
         } catch (uhe: UnknownHostException) {
             if (MTLog.isLoggable(android.util.Log.DEBUG)) {
@@ -465,17 +465,17 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
                 MTLog.w(LOG_TAG, "No Internet Connection!")
             }
             storage.saveTripUpdateLastUpdateCode(567)
-            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            storage.saveTripUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return false
         } catch (se: SocketException) {
             MTLog.w(LOG_TAG, se, "No Internet Connection!")
             storage.saveTripUpdateLastUpdateCode(567)
-            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            storage.saveTripUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return false
         } catch (ioe: IOException) {
             MTLog.w(LOG_TAG, ioe, "I/O error!")
             storage.saveTripUpdateLastUpdateCode(567)
-            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            storage.saveTripUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return false
         } catch (e: Exception) { // Unknown error
             MTLog.e(LOG_TAG, e, "INTERNAL ERROR: Unknown Exception")

--- a/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
@@ -252,8 +252,8 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
             return null
         } catch (iioe: InterruptedIOException) {
             MTLog.w(LOG_TAG, iioe, "Connection timeout!")
-            storage.saveTripUpdateLastUpdateCode(567)
-            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            storage.saveVehicleLocationLastUpdateCode(567)
+            storage.saveVehicleLocationLastUpdateMs(TimeUtils.currentTimeMillis())
             return null
         } catch (uhe: UnknownHostException) {
             if (MTLog.isLoggable(android.util.Log.DEBUG)) {
@@ -261,18 +261,18 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
             } else {
                 MTLog.w(LOG_TAG, "No Internet Connection!")
             }
-            storage.saveTripUpdateLastUpdateCode(567)
-            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            storage.saveVehicleLocationLastUpdateCode(567)
+            storage.saveVehicleLocationLastUpdateMs(TimeUtils.currentTimeMillis())
             return null
         } catch (se: SocketException) {
             MTLog.w(LOG_TAG, se, "No Internet Connection!")
-            storage.saveTripUpdateLastUpdateCode(567)
-            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            storage.saveVehicleLocationLastUpdateCode(567)
+            storage.saveVehicleLocationLastUpdateMs(TimeUtils.currentTimeMillis())
             return null
         } catch (ioe: IOException) {
             MTLog.w(LOG_TAG, ioe, "I/O error!")
-            storage.saveTripUpdateLastUpdateCode(567)
-            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            storage.saveVehicleLocationLastUpdateCode(567)
+            storage.saveVehicleLocationLastUpdateMs(TimeUtils.currentTimeMillis())
             return null
         } catch (e: Exception) { // Unknown error
             MTLog.e(LOG_TAG, e, "INTERNAL ERROR: Unknown Exception")

--- a/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/vehiclelocations/GTFSRealTimeVehiclePositionsProvider.kt
@@ -36,6 +36,8 @@ import org.mtransit.android.commons.provider.gtfs.storage
 import org.mtransit.android.commons.provider.vehiclelocations.VehicleLocationProvider.Companion.getCachedVehicleLocationsS
 import org.mtransit.android.commons.provider.vehiclelocations.model.VehicleLocation
 import org.mtransit.android.commons.secsToInstant
+import java.io.IOException
+import java.io.InterruptedIOException
 import java.net.HttpURLConnection
 import java.net.SocketException
 import java.net.UnknownHostException
@@ -248,15 +250,29 @@ object GTFSRealTimeVehiclePositionsProvider : MTLog.Loggable {
             storage.saveVehicleLocationLastUpdateCode(567) // SSL certificate not trusted (on this device)
             storage.saveVehicleLocationLastUpdateMs(TimeUtils.currentTimeMillis())
             return null
+        } catch (iioe: InterruptedIOException) {
+            MTLog.w(LOG_TAG, iioe, "Connection timeout!")
+            storage.saveTripUpdateLastUpdateCode(567)
+            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            return null
         } catch (uhe: UnknownHostException) {
             if (MTLog.isLoggable(android.util.Log.DEBUG)) {
                 MTLog.w(LOG_TAG, uhe, "No Internet Connection!")
             } else {
                 MTLog.w(LOG_TAG, "No Internet Connection!")
             }
+            storage.saveTripUpdateLastUpdateCode(567)
+            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return null
         } catch (se: SocketException) {
             MTLog.w(LOG_TAG, se, "No Internet Connection!")
+            storage.saveTripUpdateLastUpdateCode(567)
+            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
+            return null
+        } catch (ioe: IOException) {
+            MTLog.w(LOG_TAG, ioe, "I/O error!")
+            storage.saveTripUpdateLastUpdateCode(567)
+            storage.saveServiceUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
             return null
         } catch (e: Exception) { // Unknown error
             MTLog.e(LOG_TAG, e, "INTERNAL ERROR: Unknown Exception")


### PR DESCRIPTION
<!-- 

This follows up on the GTFS-RT reconnect-loop fix by applying the same failure-path handling to the remaining GTFS-RT fetchers.  
Trip Updates and Vehicle Positions were still treating some I/O failures as transient without persisting a backoff timestamp/code.

- **Problem scope**
  - `GTFSRealTimeTripUpdatesProvider` and `GTFSRealTimeVehiclePositionsProvider` did not mirror the updated reconnect-throttling behavior added elsewhere.
  - On timeout/network I/O failures, they could keep retrying too aggressively.

- **Changes**
  - **Trip Updates provider**
    - Added explicit handling for `InterruptedIOException` and `IOException`.
    - On `InterruptedIOException`, `UnknownHostException`, `SocketException`, and `IOException`, now persists:
      - synthetic last update code `567`
      - last update timestamp via `TimeUtils.currentTimeMillis()`
  - **Vehicle Positions provider**
    - Added `InterruptedIOException` and `IOException` handling.
    - Applied the same persistence behavior (`code=567` + last update timestamp) for:
      - `InterruptedIOException`
      - `UnknownHostException`
      - `SocketException`
      - `IOException`

- **Exception-path behavior (example)**
  ```kotlin
  } catch (iioe: InterruptedIOException) {
      MTLog.w(LOG_TAG, iioe, "Connection timeout!")
      storage.saveTripUpdateLastUpdateCode(567)
      storage.saveTripUpdateLastUpdateMs(TimeUtils.currentTimeMillis())
      return false
  }
  ```

-->