### PR TITLE
GTFS-RT Trip Update > fix same stop matching

### DIFF
--- a/src/main/java/org/mtransit/android/MtLogExt.kt
+++ b/src/main/java/org/mtransit/android/MtLogExt.kt
@@ -3,8 +3,8 @@
 package org.mtransit.android
 
 import org.mtransit.android.commons.Constants
-import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.ThreadSafeDateFormatter
+import org.mtransit.android.commons.TimeUtils
 import org.mtransit.android.commons.toMillis
 import java.text.DateFormat
 import java.util.Calendar
@@ -14,7 +14,7 @@ import kotlin.time.Instant
 
 // region duration
 
-fun Long?.toDurationLog(): String? = if (Constants.DEBUG) MTLog.formatDuration(this) else this?.toString() // formatting is expensive, only in debug
+fun Long?.toDurationLog(): String? = if (Constants.DEBUG) MtLogExt.formatDuration(this) else this?.toString() // formatting is expensive, only in debug
 fun Duration?.toDurationLog(): String? = this?.inWholeMilliseconds.toDurationLog()
 
 // endregion
@@ -24,12 +24,18 @@ object MtLogExt {
         ThreadSafeDateFormatter(DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT))
     }
 
-    fun format(timeInMs: Long?): String? = try {
+    fun formatDateTime(timeInMs: Long?): String? = try {
         timeInMs?.let {
             dateTimeFormatter.formatThreadSafe(it)
         }
     } catch (e: Exception) {
-        "error"
+        "e:$timeInMs!"
+    }
+
+    fun formatDuration(durationInMs: Long?) = try {
+        durationInMs?.let { TimeUtils.formatSimpleDuration(it) }
+    } catch (e: Exception) {
+        "e:$durationInMs!"
     }
 }
 
@@ -37,7 +43,7 @@ object MtLogExt {
 
 @Deprecated("Use toDateTimeLog() instead", ReplaceWith("this.toDateTimeLog()"))
 fun Long?.formatDateTime(): String? = this.toDateTimeLog()
-fun Long?.toDateTimeLog(): String? = if (Constants.DEBUG) MtLogExt.format(this) else this?.toString() // formatting is expensive, only in debug
+fun Long?.toDateTimeLog(): String? = if (Constants.DEBUG) MtLogExt.formatDateTime(this) else this?.toString() // formatting is expensive, only in debug
 fun Date?.toDateTimeLog(): String? = this?.time.toDateTimeLog()
 fun Calendar?.toDateTimeLog(): String? = this?.time.toDateTimeLog()
 fun Instant?.toDateTimeLog(): String? = this?.toMillis().toDateTimeLog()

--- a/src/main/java/org/mtransit/android/MtLogExt.kt
+++ b/src/main/java/org/mtransit/android/MtLogExt.kt
@@ -4,7 +4,9 @@ package org.mtransit.android
 
 import org.mtransit.android.commons.Constants
 import org.mtransit.android.commons.MTLog
+import org.mtransit.android.commons.ThreadSafeDateFormatter
 import org.mtransit.android.commons.toMillis
+import java.text.DateFormat
 import java.util.Calendar
 import java.util.Date
 import kotlin.time.Duration
@@ -12,18 +14,32 @@ import kotlin.time.Instant
 
 // region duration
 
-fun Long?.toDurationLog() = MTLog.formatDuration(this)
-fun Duration?.toDurationLog() = this?.inWholeMilliseconds.toDurationLog()
+fun Long?.toDurationLog(): String? = if (Constants.DEBUG) MTLog.formatDuration(this) else this?.toString() // formatting is expensive, only in debug
+fun Duration?.toDurationLog(): String? = this?.inWholeMilliseconds.toDurationLog()
 
 // endregion
+
+object MtLogExt {
+    private val dateTimeFormatter: ThreadSafeDateFormatter by lazy {
+        ThreadSafeDateFormatter(DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT))
+    }
+
+    fun format(timeInMs: Long?): String? = try {
+        timeInMs?.let {
+            dateTimeFormatter.formatThreadSafe(it)
+        }
+    } catch (e: Exception) {
+        "error"
+    }
+}
 
 // region date & time
 
 @Deprecated("Use toDateTimeLog() instead", ReplaceWith("this.toDateTimeLog()"))
-fun Long?.formatDateTime() = this.toDateTimeLog()
-fun Long?.toDateTimeLog() = if (Constants.DEBUG) MTLog.makeTime(this) else MTLog.formatDateTime(this)
-fun Date?.toDateTimeLog() = this?.time.toDateTimeLog()
-fun Calendar?.toDateTimeLog() = this?.time.toDateTimeLog()
-fun Instant?.toDateTimeLog() = this?.toMillis().toDateTimeLog()
+fun Long?.formatDateTime(): String? = this.toDateTimeLog()
+fun Long?.toDateTimeLog(): String? = if (Constants.DEBUG) MtLogExt.format(this) else this?.toString() // formatting is expensive, only in debug
+fun Date?.toDateTimeLog(): String? = this?.time.toDateTimeLog()
+fun Calendar?.toDateTimeLog(): String? = this?.time.toDateTimeLog()
+fun Instant?.toDateTimeLog(): String? = this?.toMillis().toDateTimeLog()
 
 // endregion

--- a/src/main/java/org/mtransit/android/commons/MTLog.java
+++ b/src/main/java/org/mtransit/android/commons/MTLog.java
@@ -378,22 +378,22 @@ public final class MTLog {
 		if (Constants.DEBUG) {
 			logMsg = StringUtils.oneLineOneSpace(logMsg);
 		}
-		final String time = makeTime(TimeUtils.systemCurrentTimeMillis()); // need stable ASC timestamp (more than exact time)
+		final String time = makeLogTime(TimeUtils.systemCurrentTimeMillis()); // need stable ASC timestamp (more than exact time)
 		return String.format("%s:%s>%s", time, tag, logMsg);
 	}
 
 	@Nullable
-	public static String makeTime(@Nullable Calendar calendar) {
-		return calendar == null ? null : makeTime(calendar.getTimeInMillis());
+	public static String makeLogTime(@Nullable Calendar calendar) {
+		return calendar == null ? null : makeLogTime(calendar.getTimeInMillis());
 	}
 
 	@Nullable
-	public static String makeTime(@Nullable Long timeInMs) {
-		return timeInMs == null ? null : makeTime(timeInMs.longValue());
+	public static String makeLogTime(@Nullable Long timeInMs) {
+		return timeInMs == null ? null : makeLogTime(timeInMs.longValue());
 	}
 
 	@NonNull
-	public static String makeTime(long timeMs) {
+	public static String makeLogTime(long timeMs) {
 		return Constants.DEBUG ? LOG_TIME_FORMAT.formatThreadSafe(timeMs) : String.valueOf(timeMs);
 	}
 

--- a/src/main/java/org/mtransit/android/commons/data/POIStatusExt.kt
+++ b/src/main/java/org/mtransit/android/commons/data/POIStatusExt.kt
@@ -4,3 +4,9 @@ import org.mtransit.android.commons.millisToInstant
 import kotlin.time.Instant
 
 val POIStatus.readFromSource: Instant? get() = this.readFromSourceAtInMs.takeIf { it > 0 }?.millisToInstant()
+
+fun POIStatus.setReadFromSourceAtInMsKeepMostRecent(readFromSourceAtInMs: Long) {
+    if (this.readFromSourceAtInMs < readFromSourceAtInMs) {
+        this.readFromSourceAtInMs = readFromSourceAtInMs
+    }
+}

--- a/src/main/java/org/mtransit/android/commons/data/ScheduleExt.kt
+++ b/src/main/java/org/mtransit/android/commons/data/ScheduleExt.kt
@@ -67,12 +67,25 @@ fun Schedule.toNoData() = makeSchedule(
 
 val Schedule.providerPrecision get() = providerPrecisionInMs.milliseconds
 
+fun Schedule.getTripTimestamps(tripId: String) = this.timestamps.filter { it.tripId == tripId }
+fun Schedule.hasTripTimestamps(tripId: String) = this.timestamps.any { it.tripId == tripId }
+
 fun Instant.toScheduleTimestamp(localTimeZoneId: String, arrival: Instant? = null, tripId: String? = null, stopSequence: Int? = null) =
     Schedule.Timestamp(this.toMillis(), localTimeZoneId).apply {
         arrival?.let { this.arrivalT = it.toMillis() }
         tripId?.let { this.tripId = it }
         stopSequence?.let { this.setStopSequence(it) }
     }
+
+fun Schedule.setCancelled(timestamp: Schedule.Timestamp, cancelled: Boolean, includeCancelledTimestamps: Boolean) {
+    if (cancelled) {
+        if (includeCancelledTimestamps) {
+            timestamp.cancelled = true
+        } else {
+            removeTimestamp(timestamp)
+        }
+    }
+}
 
 fun Schedule.Timestamp.isDepartureLate(minDelay: Duration = 30.seconds) =
     originalDepartureDelay > minDelay

--- a/src/main/java/org/mtransit/android/commons/data/ScheduleExt.kt
+++ b/src/main/java/org/mtransit/android/commons/data/ScheduleExt.kt
@@ -68,7 +68,6 @@ fun Schedule.toNoData() = makeSchedule(
 val Schedule.providerPrecision get() = providerPrecisionInMs.milliseconds
 
 fun Schedule.getTripTimestamps(tripId: String) = this.timestamps.filter { it.tripId == tripId }
-fun Schedule.hasTripTimestamps(tripId: String) = this.timestamps.any { it.tripId == tripId }
 
 fun Instant.toScheduleTimestamp(localTimeZoneId: String, arrival: Instant? = null, tripId: String? = null, stopSequence: Int? = null) =
     Schedule.Timestamp(this.toMillis(), localTimeZoneId).apply {

--- a/src/main/java/org/mtransit/android/commons/data/ScheduleExt.kt
+++ b/src/main/java/org/mtransit/android/commons/data/ScheduleExt.kt
@@ -77,13 +77,33 @@ fun Instant.toScheduleTimestamp(localTimeZoneId: String, arrival: Instant? = nul
         stopSequence?.let { this.setStopSequence(it) }
     }
 
-fun Schedule.setCancelled(timestamp: Schedule.Timestamp, cancelled: Boolean, includeCancelledTimestamps: Boolean) {
-    if (cancelled) {
-        if (includeCancelledTimestamps) {
-            timestamp.cancelled = true
-        } else {
-            removeTimestamp(timestamp)
-        }
+fun Collection<Schedule>.setDeleted(tripId: String, readFromSourceMs: Long) =
+    forEach { it.setDeleted(tripId, readFromSourceMs) }
+
+fun Schedule.setDeleted(tripId: String, readFromSourceMs: Long) {
+    val tripTimestamps = getTripTimestamps(tripId).takeIf { it.isNotEmpty() } ?: return
+    tripTimestamps.forEach {
+        removeTimestamp(it)
+    }
+    setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
+}
+
+fun Collection<Schedule>.setCancelled(tripId: String, includeCancelledTimestamps: Boolean, readFromSourceMs: Long) =
+    forEach { it.setCancelled(tripId, includeCancelledTimestamps, readFromSourceMs) }
+
+fun Schedule.setCancelled(tripId: String, includeCancelledTimestamps: Boolean, readFromSourceMs: Long) {
+    val tripTimestamps = getTripTimestamps(tripId).takeIf { it.isNotEmpty() } ?: return
+    tripTimestamps.forEach {
+        setCancelled(it, includeCancelledTimestamps)
+    }
+    setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
+}
+
+fun Schedule.setCancelled(timestamp: Schedule.Timestamp, includeCancelledTimestamps: Boolean) {
+    if (includeCancelledTimestamps) {
+        timestamp.cancelled = true
+    } else {
+        removeTimestamp(timestamp)
     }
 }
 

--- a/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
+++ b/src/main/java/org/mtransit/android/commons/provider/GTFSRealTimeProvider.java
@@ -918,7 +918,7 @@ public class GTFSRealTimeProvider extends MTContentProvider implements
 					try {
 						final GtfsRealtime.FeedMessage gFeedMessage = GtfsRealtime.FeedMessage.parseFrom(response.body().bytes());
 						final List<Pair<GtfsRealtime.Alert, String>> alertsWithIdPair = GtfsRealtimeExt.toAlertsWithIdPair(gFeedMessage.getEntityList());
-						if (Constants.DEBUG) MTLog.d(this, "loadAgencyDataFromWWW() > GTFS alerts[%s]: ", alertsWithIdPair.size());
+						if (Constants.DEBUG) MTLog.d(this, "loadAgencyServiceUpdateDataFromWWW() > GTFS alerts[%s]: ", alertsWithIdPair.size());
 						for (Pair<GtfsRealtime.Alert, String> gAlertAndId : GtfsRealtimeExt.sortAlertsPair(alertsWithIdPair, newLastUpdateInMs)) {
 							final GtfsRealtime.Alert gAlert = gAlertAndId.getFirst();
 							final String feedEntityId = gAlertAndId.getSecond();

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealtimeExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealtimeExt.kt
@@ -281,7 +281,7 @@ object GtfsRealtimeExt {
             buildList {
                 optDelayMs?.let { add(if (short) "d=${it.toDurationLog()}" else "delay=${it.toDurationLog()}") }
                 optTimeMs?.let { add(if (short) "t=${it.toDateTimeLog()}" else "time=${it.toDateTimeLog()}") }
-                optUncertainty?.let { add(if (short) "u=$it" else "uncertainty=$it") }
+                optUncertaintyInMs?.let { add(if (short) "u=${it.toDurationLog()}" else "uncertainty=${it.toDurationLog()}") }
                 optScheduledTimeMs?.let { add(if (short) "sT=${it.toDateTimeLog()}" else "schedTime=${it.toDateTimeLog()}") }
             }.joinToStringList()
         )
@@ -294,6 +294,8 @@ object GtfsRealtimeExt {
     val GTUStopTimeEvent.optTimeMs get() = optTime?.secToMs()
     val GTUStopTimeEvent.optTimeInstant get() = optTime?.secsToInstant()
     val GTUStopTimeEvent.optUncertainty get() = if (hasUncertainty()) uncertainty else null
+    val GTUStopTimeEvent.optUncertaintyInMs get() = optUncertainty?.secToMs()
+    val GTUStopTimeEvent.optUncertaintyDuration get() = optUncertainty?.seconds
     val GTUStopTimeEvent.optScheduledTime get() = if (hasScheduledTime()) scheduledTime else null
     val GTUStopTimeEvent.optScheduledTimeMs get() = optScheduledTime?.secToMs()
     val GTUStopTimeEvent.optScheduledTimeInstant get() = optScheduledTime?.secsToInstant()

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealtimeExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealtimeExt.kt
@@ -107,11 +107,11 @@ object GtfsRealtimeExt {
 
     @JvmStatic
     fun List<GTripUpdate>.sortTripUpdates(): List<GTripUpdate> =
-        this.sortedBy { it.optTimestamp }
+        this.sortedBy { it.optTimestamp ?: 0L }
 
     @JvmStatic
     fun List<Pair<GTripUpdate, String>>.sortTripUpdatesPair(): List<Pair<GTripUpdate, String>> =
-        this.sortedBy { (it, _) -> it.optTimestamp }
+        this.sortedBy { (it, _) -> it.optTimestamp ?: 0L }
 
     @JvmStatic
     fun List<GFeedEntity>.toVehicles(): List<GVehiclePosition> =
@@ -123,11 +123,11 @@ object GtfsRealtimeExt {
 
     @JvmStatic
     fun List<GVehiclePosition>.sortVehicles(): List<GVehiclePosition> =
-        this.sortedBy { it.timestamp }
+        this.sortedBy { it.optTimestamp ?: 0L }
 
     @JvmStatic
     fun List<Pair<GVehiclePosition, String>>.sortVehiclesPair(): List<Pair<GVehiclePosition, String>> =
-        this.sortedBy { (vehiclePosition, _) -> vehiclePosition.timestamp }
+        this.sortedBy { (vehiclePosition, _) -> vehiclePosition.optTimestamp ?: 0L }
 
     @JvmStatic
     fun List<GFeedEntity>.toAlerts(): List<GAlert> =

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealtimeExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsRealtimeExt.kt
@@ -107,11 +107,11 @@ object GtfsRealtimeExt {
 
     @JvmStatic
     fun List<GTripUpdate>.sortTripUpdates(): List<GTripUpdate> =
-        this.sortedBy { it.timestamp }
+        this.sortedBy { it.optTimestamp }
 
     @JvmStatic
     fun List<Pair<GTripUpdate, String>>.sortTripUpdatesPair(): List<Pair<GTripUpdate, String>> =
-        this.sortedBy { (it, _) -> it.timestamp }
+        this.sortedBy { (it, _) -> it.optTimestamp }
 
     @JvmStatic
     fun List<GFeedEntity>.toVehicles(): List<GVehiclePosition> =

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -121,7 +121,7 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
         MTLog.d(LOG_TAG, "makeCachedStatusFromAgencyData(${filter.targetUUID}, ${staticRDTripIds.size})")
         val lastUpdateInMs = storage.getTripUpdateLastUpdateMs(0L)
             .takeIf { it > 0L } ?: return null // never loaded
-        val readFromSourceMs = storage.getTripUpdateReadFromSourceMs(0L)
+        val feedReadFromSourceMs = storage.getTripUpdateReadFromSourceMs(0L)
             .takeIf { it > 0L } ?: lastUpdateInMs
         val gTripUpdates = gTripUpdates ?: return null
         val sourceLabel = SourceUtils.getSourceLabel( // always use source from official API
@@ -172,7 +172,7 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
                     rds.makeSchedule(
                         lastUpdateInMs = lastUpdateInMs,
                         validityInMs = getStatusValidityInMs(false),
-                        readFromSourceAtInMs = readFromSourceMs,
+                        readFromSourceAtInMs = feedReadFromSourceMs,
                         providerPrecisionInMs = PROVIDER_PRECISION_IN_MS,
                         sourceLabel = sourceLabel,
                         noData = true, // NO DATA
@@ -202,8 +202,14 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
             }
             if (sortedRDS.isEmpty()) return null
             if (uuidSchedule.isEmpty()) return null
-            processRDTripUpdates(rdTripUpdates, uuidSchedule, sortedRDS, filter.isIncludeCancelledTimestampsOrDefault)
-            cacheRealTimeSchedules(uuidSchedule.values, sourceLabel, readFromSourceMs, readFromSourceMs)
+            processRDTripUpdates(
+                rdTripUpdates = rdTripUpdates,
+                targetUuidSchedule = uuidSchedule,
+                sortedRDS = sortedRDS,
+                feedReadFromSourceMs = feedReadFromSourceMs,
+                includeCancelledTimestamps = filter.isIncludeCancelledTimestampsOrDefault,
+            )
+            cacheRealTimeSchedules(scheduleList = uuidSchedule.values, sourceLabel = sourceLabel, lastUpdateInMs = lastUpdateInMs)
             return getCachedStatusS(filter.targetUUID, staticRDTripIds)
         } catch (e: Exception) {
             MTLog.w(LOG_TAG, e, "makeCachedStatusFromAgencyData() > error!")
@@ -259,7 +265,6 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
         scheduleList: Collection<Schedule>,
         sourceLabel: String,
         lastUpdateInMs: Long,
-        readFromSourceMs: Long,
         ignorePastRealTime: Boolean = false,
         tripsWithRealTime: Set<String> = scheduleList
             .asSequence()
@@ -271,7 +276,6 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
         scheduleList.forEach { schedule ->
             schedule.sourceLabel = sourceLabel
             schedule.lastUpdateInMs = lastUpdateInMs
-            schedule.readFromSourceAtInMs = readFromSourceMs
             schedule.providerPrecisionInMs = PROVIDER_PRECISION_IN_MS
             schedule.validityInMs = getStatusValidityInMs(false)
             val now = TimeUtilsK.currentInstant()

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -142,9 +142,8 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
             val sortedRDS by lazy {
                 context.getRDS(targetAuthority, targetRoute.id, targetDirection.id).orEmpty()
             }
-            val uuidSchedule by lazy {
+            val rdSchedules: Collection<Schedule> by lazy {
                 context.getRDSSchedule(targetAuthority, sortedRDS, filter.isIncludeCancelledTimestampsOrDefault)
-                    .associateBy { it.targetUUID }
             }
             val rdTripUpdates = gTripUpdates
                 .filter { it.isUseful() }
@@ -201,15 +200,15 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
                 }
             }
             if (sortedRDS.isEmpty()) return null
-            if (uuidSchedule.isEmpty()) return null
+            if (rdSchedules.isEmpty()) return null
             processRDTripUpdates(
                 rdTripUpdates = rdTripUpdates,
-                targetUuidSchedule = uuidSchedule,
+                rdSchedules = rdSchedules,
                 sortedRDS = sortedRDS,
                 feedReadFromSourceMs = feedReadFromSourceMs,
                 includeCancelledTimestamps = filter.isIncludeCancelledTimestampsOrDefault,
             )
-            cacheRealTimeSchedules(scheduleList = uuidSchedule.values, sourceLabel = sourceLabel, lastUpdateInMs = lastUpdateInMs)
+            cacheRealTimeSchedules(scheduleList = rdSchedules, sourceLabel = sourceLabel, lastUpdateInMs = lastUpdateInMs)
             return getCachedStatusS(filter.targetUUID, staticRDTripIds)
         } catch (e: Exception) {
             MTLog.w(LOG_TAG, e, "makeCachedStatusFromAgencyData() > error!")

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -66,8 +66,9 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
         val tripSchedules = schedulesByTripId[tripId]
             ?.takeIf { it.isNotEmpty() }
             ?: return@forEach
+        val tripScheduleUUIDs = tripSchedules.map { it.targetUUID }.toSet()
         val tripSortedRDS = sortedRDS
-            .filter { rds -> tripSchedules.any { it.targetUUID == rds.uuid } }
+            .filter { rds -> rds.uuid in tripScheduleUUIDs }
             .takeIf { it.isNotEmpty() }
             ?: return@forEach
         val sortedTargetUuidAndSequence = makeTargetUuidAndSequenceList(tripId, tripSchedules, tripSortedRDS)
@@ -93,14 +94,12 @@ internal fun makeTargetUuidAndSequenceList(
             }
             .sortedBy { (_, stopSequence) -> stopSequence }
     }
-    var generatedStopSequence = 1
     return buildSet { // unicity of uuid+sequence
         tripSchedules.forEach { schedule->
             schedule.getTripTimestamps(tripId).forEach { timestamp ->
-                val stopSequence = timestamp.stopSequenceOrNull
-                    ?: generatedStopSequence /** should not happen if FF is turned ON [org.mtransit.commons.FeatureFlags.F_EXPORT_STOP_SEQUENCE] */
-                add(schedule.targetUUID to stopSequence)
-                generatedStopSequence = stopSequence + 1 /** should not happen if FF is turned ON [org.mtransit.commons.FeatureFlags.F_EXPORT_STOP_SEQUENCE] */
+                timestamp.stopSequenceOrNull?.let { stopSequence ->
+                    add(schedule.targetUUID to stopSequence)
+                }
             }
         }
     }.sortedBy { (_, stopSequence) -> stopSequence }
@@ -218,10 +217,20 @@ internal fun applyDelaySTU(
     val stuDepartureDelay = gStopTimeUpdate.optDeparture
         .takeIf { gStopTimeUpdate.scheduleRelationship != GTUSTUScheduleRelationship.NO_DATA }
         .makeDelay(timestampOriginalDeparture, stuArrivalDelay, timestampOriginalArrivalDiff)
-    stuArrivalTime?.let { rdsTripTimestamp.updateArrivalForRealTime(newArrival = it); updated = true }
-        ?: stuArrivalDelay?.let { rdsTripTimestamp.updateArrivalForRealTime(it, rdsSchedule.providerPrecision, PROVIDER_PRECISION); updated = true }
-    stuDepartureTime?.let { rdsTripTimestamp.updateDepartureForRealTime(newDeparture = it); updated = true }
-        ?: stuDepartureDelay?.let { rdsTripTimestamp.updateDepartureForRealTime(it, rdsSchedule.providerPrecision, PROVIDER_PRECISION); updated = true }
+    if (stuArrivalTime != null) {
+        rdsTripTimestamp.updateArrivalForRealTime(newArrival = stuArrivalTime)
+        updated = true
+    } else if (stuArrivalDelay != null) {
+        rdsTripTimestamp.updateArrivalForRealTime(stuArrivalDelay, rdsSchedule.providerPrecision, PROVIDER_PRECISION)
+        updated = true
+    }
+    if (stuDepartureTime != null) {
+        rdsTripTimestamp.updateDepartureForRealTime(newDeparture = stuDepartureTime)
+        updated = true
+    } else if (stuDepartureDelay != null) {
+        rdsTripTimestamp.updateDepartureForRealTime(stuDepartureDelay, rdsSchedule.providerPrecision, PROVIDER_PRECISION)
+        updated = true
+    }
     if (gStopTimeUpdate.scheduleRelationship == GTUSTUScheduleRelationship.SKIPPED) {
         rdsSchedule.setCancelled(rdsTripTimestamp, includeCancelledTimestamps)
         updated = true

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -1,5 +1,6 @@
 package org.mtransit.android.commons.provider.status
 
+import androidx.annotation.VisibleForTesting
 import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.TimeUtilsK
 import org.mtransit.android.commons.data.RouteDirectionStop
@@ -261,16 +262,19 @@ internal fun applyDelay(
 private fun GTFSRealTimeProvider.isSameStop(stopTimeUpdate: GTUStopTimeUpdate?, rds: RouteDirectionStop?, stopSequence: Int) =
     stopTimeUpdate?.isSameStop(rds, stopSequence, this::parseStopId) == true
 
+@VisibleForTesting
 internal fun GTUStopTimeUpdate.isSameStop(
     rds: RouteDirectionStop?,
     stopSequence: Int,
     parseStopId: (String) -> String,
 ): Boolean {
     rds ?: return false
-    val sameOrUnspecifiedStopSequence = this.optStopSequence
-        ?.let { it == stopSequence }
+    val sameOrUnspecifiedStopSequence = this.optStopSequence?.let {
+        it == stopSequence
+    }
     val sameOrUnspecifiedStopId = this.optStopIdNotEmpty?.let {
         rds.stop.isSameOriginalId(parseStopId(it))
     }
-    return sameOrUnspecifiedStopSequence == true || sameOrUnspecifiedStopId == true
+    if (sameOrUnspecifiedStopSequence == null && sameOrUnspecifiedStopId == null) return false
+    return sameOrUnspecifiedStopSequence != false && sameOrUnspecifiedStopId != false
 }

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -9,7 +9,6 @@ import org.mtransit.android.commons.data.arrival
 import org.mtransit.android.commons.data.arrivalDiff
 import org.mtransit.android.commons.data.departure
 import org.mtransit.android.commons.data.getTripTimestamps
-import org.mtransit.android.commons.data.hasTripTimestamps
 import org.mtransit.android.commons.data.providerPrecision
 import org.mtransit.android.commons.data.setCancelled
 import org.mtransit.android.commons.data.setDeleted
@@ -53,12 +52,19 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
     feedReadFromSourceMs: Long,
     includeCancelledTimestamps: Boolean = false,
 ) {
+    val schedulesByTripId = mutableMapOf<String, MutableSet<Schedule>>()
+    rdSchedules.forEach { schedule ->
+        schedule.timestamps.forEach { timestamp ->
+            timestamp.tripId?.let { tripId ->
+                schedulesByTripId.getOrPut(tripId) { mutableSetOf() }.add(schedule)
+            }
+        }
+    }
     rdTripUpdates.forEach { (td, gTripUpdate) ->
         val gTripId = td.optTripIdNotEmpty ?: return@forEach
         val tripId = parseTripId(gTripId)
-        val tripSchedules = rdSchedules
-            .filter { schedule -> schedule.hasTripTimestamps(tripId) }
-            .takeIf { it.isNotEmpty() }
+        val tripSchedules = schedulesByTripId[tripId]
+            ?.takeIf { it.isNotEmpty() }
             ?: return@forEach
         val tripSortedRDS = sortedRDS
             .filter { rds -> tripSchedules.any { it.targetUUID == rds.uuid } }
@@ -123,6 +129,7 @@ internal fun processRDTripUpdate(
         MTLog.d(LOG_TAG, "processRDTripUpdate($tripId) > SKIP (useless trip update: ${gTripUpdate.toStringExt()})")
         return // nothing to do
     }
+    val tripSchedulesByUUID = tripSchedules.associateBy { it.targetUUID }
     var stuIdx = 0
     var uuidAndSeqIdx = 0
     var currentDelay = gTripUpdate.optDelayDuration // initial delay valid until 1st stop time update
@@ -140,7 +147,7 @@ internal fun processRDTripUpdate(
             currentDelay = applyDelay(
                 tripId = tripId,
                 stopSequence = currentUuidAndSeq.stopSequence,
-                rdsSchedule = tripSchedules.firstOrNull { it.targetUUID == currentRDS.uuid},
+                rdsSchedule = tripSchedulesByUUID[currentRDS.uuid],
                 currentDelay = currentDelay,
                 readFromSourceMs = gTripUpdateReadFromSourceMs
             )
@@ -153,7 +160,7 @@ internal fun processRDTripUpdate(
         currentDelay = applyDelaySTU(
             tripId = tripId,
             stopSequence = currentUuidAndSeq.stopSequence,
-            rdsSchedule = tripSchedules.firstOrNull { it.targetUUID == currentRDS.uuid},
+            rdsSchedule = tripSchedulesByUUID[currentRDS.uuid],
             gStopTimeUpdate = currentStopTimeUpdate,
             readFromSourceMs = gTripUpdateReadFromSourceMs,
             currentDelay = currentDelay,

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -79,9 +79,7 @@ internal fun makeTargetUuidAndSequenceList(
     tripTargetUuidSchedule: Map<String, Schedule>,
     tripSortedRDS: List<RouteDirectionStop>,
 ): List<Pair<String, Int>> {
-    if (tripTargetUuidSchedule.values.any { schedule ->
-            schedule.getTripTimestamps(tripId).any { timestamp -> timestamp.stopSequenceOrNull == null }
-        }) {
+    if (tripTargetUuidSchedule.values.any { schedule -> schedule.timestamps.any { it.tripId == tripId && it.stopSequenceOrNull == null } }) {
         /** should not happen if FF is turned ON [org.mtransit.commons.FeatureFlags.F_EXPORT_STOP_SEQUENCE] */
         return tripSortedRDS
             .mapIndexed { index, rds ->
@@ -156,7 +154,7 @@ internal fun processRDTripUpdate(
             stopSequence = currentUuidAndSeq.second,
             rdsSchedule = tripTargetUuidSchedule[currentRDS.uuid],
             gStopTimeUpdate = currentStopTimeUpdate,
-            readFromSourceMs = gTripUpdate.optTimestampMs ?: feedReadFromSourceMs,
+            readFromSourceMs = gTripUpdateReadFromSourceMs,
             currentDelay = currentDelay,
             includeCancelledTimestamps = includeCancelledTimestamps,
         )

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -8,19 +8,25 @@ import org.mtransit.android.commons.data.Schedule
 import org.mtransit.android.commons.data.arrival
 import org.mtransit.android.commons.data.arrivalDiff
 import org.mtransit.android.commons.data.departure
+import org.mtransit.android.commons.data.getTripTimestamps
+import org.mtransit.android.commons.data.hasTripTimestamps
 import org.mtransit.android.commons.data.providerPrecision
+import org.mtransit.android.commons.data.setCancelled
+import org.mtransit.android.commons.data.setReadFromSourceAtInMsKeepMostRecent
 import org.mtransit.android.commons.data.updateArrivalForRealTime
 import org.mtransit.android.commons.data.updateDepartureForRealTime
 import org.mtransit.android.commons.data.updateForRealTime
 import org.mtransit.android.commons.provider.GTFSRealTimeProvider
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optArrival
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDelay
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDelayDuration
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optDeparture
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optScheduleRelationship
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStopIdNotEmpty
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStopSequence
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStopTimeUpdateList
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTimeInstant
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTimestampMs
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTripIdNotEmpty
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
@@ -28,8 +34,9 @@ import org.mtransit.android.commons.provider.gtfs.parseStopId
 import org.mtransit.android.commons.provider.gtfs.parseTripId
 import org.mtransit.android.commons.provider.status.GTFSRealTimeTripUpdatesProvider.LOG_TAG
 import org.mtransit.android.commons.provider.status.GTFSRealTimeTripUpdatesProvider.PROVIDER_PRECISION
+import org.mtransit.android.toDateTimeLog
+import org.mtransit.android.toDurationLog
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor as GTripDescriptor
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship as GTDScheduleRelationship
@@ -40,15 +47,16 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate.Schedu
 
 fun GTFSRealTimeProvider.processRDTripUpdates(
     rdTripUpdates: List<Pair<GTripDescriptor, GTripUpdate>>,
-    targetUuidSchedule: Map<String, Schedule?>,
+    targetUuidSchedule: Map<String, Schedule>,
     sortedRDS: List<RouteDirectionStop>,
+    feedReadFromSourceMs: Long,
     includeCancelledTimestamps: Boolean = false,
 ) {
     rdTripUpdates.forEach { (td, gTripUpdate) ->
         val gTripId = td.optTripIdNotEmpty ?: return@forEach
         val tripId = parseTripId(gTripId)
         val tripTargetUuidSchedule = targetUuidSchedule
-            .filter { (_, schedule) -> schedule?.timestamps?.any { it.tripId == tripId } == true }
+            .filter { (_, schedule) -> schedule.hasTripTimestamps(tripId) }
             .takeIf { it.isNotEmpty() }
             ?: return@forEach
         val tripSortedRDS = sortedRDS
@@ -59,6 +67,7 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
         processRDTripUpdate(
             tripId, gTripUpdate, tripSortedRDS, sortedTargetUuidAndSequence, tripTargetUuidSchedule,
             isSameStop = { stu, rds, stopSeq -> isSameStop(stu, rds, stopSeq) },
+            feedReadFromSourceMs = feedReadFromSourceMs,
             includeCancelledTimestamps = includeCancelledTimestamps,
         )
     }
@@ -66,13 +75,13 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
 
 internal fun makeTargetUuidAndSequenceList(
     tripId: String,
-    tripTargetUuidSchedule: Map<String, Schedule?>,
+    tripTargetUuidSchedule: Map<String, Schedule>,
     tripSortedRDS: List<RouteDirectionStop>,
 ): List<Pair<String, Int>> {
-    if (tripTargetUuidSchedule.values.any {
-            it?.timestamps?.filter { timestamp -> timestamp.tripId == tripId }?.any { timestamp -> timestamp.stopSequenceOrNull == null } == true
+    if (tripTargetUuidSchedule.values.any { schedule ->
+            schedule.getTripTimestamps(tripId).any { timestamp -> timestamp.stopSequenceOrNull == null }
         }) {
-        // should not happen if FF is turned ON
+        /** should not happen if FF is turned ON [org.mtransit.commons.FeatureFlags.F_EXPORT_STOP_SEQUENCE] */
         return tripSortedRDS
             .mapIndexed { index, rds ->
                 rds.uuid to index + 1 // generated stop sequence
@@ -82,7 +91,7 @@ internal fun makeTargetUuidAndSequenceList(
     var generatedStopSequence = 1
     return buildSet { // unicity of uuid+sequence
         tripTargetUuidSchedule.forEach { (targetUuid, schedule) ->
-            schedule?.timestamps?.filter { it.tripId == tripId }?.forEach { timestamp ->
+            schedule.getTripTimestamps(tripId).forEach { timestamp ->
                 val stopSequence = timestamp.stopSequenceOrNull ?: generatedStopSequence
                 add(targetUuid to stopSequence)
                 generatedStopSequence = stopSequence + 1 // next probable stop sequence
@@ -96,28 +105,31 @@ internal fun processRDTripUpdate(
     gTripUpdate: GTripUpdate,
     tripSortedRDS: List<RouteDirectionStop>,
     sortedTargetUuidAndSequence: List<Pair<String, Int>>,
-    tripTargetUuidSchedule: Map<String, Schedule?>,
+    tripTargetUuidSchedule: Map<String, Schedule>,
     isSameStop: (GTUStopTimeUpdate?, RouteDirectionStop, Int) -> Boolean,
+    feedReadFromSourceMs: Long,
     includeCancelledTimestamps: Boolean = false,
 ) {
     if (gTripUpdate.optTrip?.optScheduleRelationship == GTDScheduleRelationship.DELETED) {
         tripTargetUuidSchedule.values.forEach { schedule ->
-            schedule ?: return@forEach
-            schedule.timestamps.filter { it.tripId == tripId }.forEach {
+            val tripTimestamps = schedule.getTripTimestamps(tripId)
+            tripTimestamps.forEach {
                 schedule.removeTimestamp(it)
+            }
+            if (tripTimestamps.isNotEmpty()) {
+                schedule.setReadFromSourceAtInMsKeepMostRecent(gTripUpdate.optTimestampMs ?: feedReadFromSourceMs)
             }
         }
         return
     }
     if (gTripUpdate.optTrip?.optScheduleRelationship == GTDScheduleRelationship.CANCELED) {
         tripTargetUuidSchedule.values.forEach { schedule ->
-            schedule ?: return@forEach
-            schedule.timestamps.filter { it.tripId == tripId }.forEach { timestamp ->
-                if (includeCancelledTimestamps) {
-                    timestamp.cancelled = true
-                } else {
-                    schedule.removeTimestamp(timestamp)
-                }
+            val tripTimestamps = schedule.getTripTimestamps(tripId)
+            tripTimestamps.forEach { timestamp ->
+                schedule.setCancelled(timestamp, true, includeCancelledTimestamps)
+            }
+            if (tripTimestamps.isNotEmpty()) {
+                schedule.setReadFromSourceAtInMsKeepMostRecent(gTripUpdate.optTimestampMs ?: feedReadFromSourceMs)
             }
         }
         return
@@ -128,7 +140,7 @@ internal fun processRDTripUpdate(
     }
     var stuIdx = 0
     var uuidAndSeqIdx = 0
-    var currentDelay = gTripUpdate.optDelay?.seconds // initial delay valid until 1st stop time update
+    var currentDelay = gTripUpdate.optDelayDuration // initial delay valid until 1st stop time update
     val gStopTimeUpdates = gTripUpdate.optStopTimeUpdateList?.sortedBy { it.optStopSequence }
     var currentStopTimeUpdate: GTUStopTimeUpdate?
     var nextStopTimeUpdate: GTUStopTimeUpdate? = gStopTimeUpdates?.getOrNull(stuIdx)
@@ -145,6 +157,7 @@ internal fun processRDTripUpdate(
                 stopSequence = currentUuidAndSeq.second,
                 rdsSchedule = tripTargetUuidSchedule[currentRDS.uuid],
                 currentDelay = currentDelay,
+                readFromSourceMs = gTripUpdate.optTimestampMs ?: feedReadFromSourceMs
             )
             currentUuidAndSeq = sortedTargetUuidAndSequence.getOrNull(++uuidAndSeqIdx) ?: break // no more stop
             currentRDS = tripSortedRDS.singleOrNull { it.uuid == currentUuidAndSeq.first } ?: break // stop not found!
@@ -157,6 +170,7 @@ internal fun processRDTripUpdate(
             stopSequence = currentUuidAndSeq.second,
             rdsSchedule = tripTargetUuidSchedule[currentRDS.uuid],
             gStopTimeUpdate = currentStopTimeUpdate,
+            readFromSourceMs = gTripUpdate.optTimestampMs ?: feedReadFromSourceMs,
             currentDelay = currentDelay,
             includeCancelledTimestamps = includeCancelledTimestamps,
         )
@@ -185,6 +199,7 @@ internal fun applyDelaySTU(
     stopSequence: Int,
     rdsSchedule: Schedule?,
     gStopTimeUpdate: GTUStopTimeUpdate,
+    readFromSourceMs: Long,
     currentDelay: Duration? = null,
     includeCancelledTimestamps: Boolean = false,
 ): Duration? {
@@ -193,6 +208,7 @@ internal fun applyDelaySTU(
     val timestampOriginalArrival = rdsTripTimestamp.arrival
     val timestampOriginalDeparture = rdsTripTimestamp.departure
     val timestampOriginalArrivalDiff = rdsTripTimestamp.arrivalDiff
+    var updated = false
     val stuArrivalTime = gStopTimeUpdate.optArrival
         .takeIf { gStopTimeUpdate.scheduleRelationship != GTUSTUScheduleRelationship.NO_DATA }
         ?.optTimeInstant
@@ -207,17 +223,15 @@ internal fun applyDelaySTU(
     val stuDepartureDelay = gStopTimeUpdate.optDeparture
         .takeIf { gStopTimeUpdate.scheduleRelationship != GTUSTUScheduleRelationship.NO_DATA }
         .makeDelay(timestampOriginalDeparture, stuArrivalDelay, timestampOriginalArrivalDiff)
-    stuArrivalTime?.let { rdsTripTimestamp.updateArrivalForRealTime(newArrival = it) }
-        ?: stuArrivalDelay?.let { rdsTripTimestamp.updateArrivalForRealTime(it, rdsSchedule.providerPrecision, PROVIDER_PRECISION) }
-    stuDepartureTime?.let { rdsTripTimestamp.updateDepartureForRealTime(newDeparture = it) }
-        ?: stuDepartureDelay?.let { rdsTripTimestamp.updateDepartureForRealTime(it, rdsSchedule.providerPrecision, PROVIDER_PRECISION) }
+    stuArrivalTime?.let { rdsTripTimestamp.updateArrivalForRealTime(newArrival = it); updated = true }
+        ?: stuArrivalDelay?.let { rdsTripTimestamp.updateArrivalForRealTime(it, rdsSchedule.providerPrecision, PROVIDER_PRECISION); updated = true }
+    stuDepartureTime?.let { rdsTripTimestamp.updateDepartureForRealTime(newDeparture = it); updated = true }
+        ?: stuDepartureDelay?.let { rdsTripTimestamp.updateDepartureForRealTime(it, rdsSchedule.providerPrecision, PROVIDER_PRECISION); updated = true }
     if (gStopTimeUpdate.scheduleRelationship == GTUSTUScheduleRelationship.SKIPPED) {
-        if (includeCancelledTimestamps) {
-            rdsTripTimestamp.cancelled = true
-        } else {
-            rdsSchedule.removeTimestamp(rdsTripTimestamp)
-        }
+        rdsSchedule.setCancelled(rdsTripTimestamp, true, includeCancelledTimestamps)
+        updated = true
     }
+    if (updated) rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
     return stuDepartureDelay
         .takeIf { gStopTimeUpdate.scheduleRelationship != GTUSTUScheduleRelationship.NO_DATA }
 }
@@ -227,7 +241,7 @@ internal fun GTUStopTimeEvent?.makeDelay(
     previousSTEDelay: Duration? = null,
     previousCurrentDiff: Duration? = null,
 ): Duration? {
-    return this?.optDelay?.seconds
+    return this?.optDelayDuration
         ?: this?.optTimeInstant?.let { time -> time - originalTime }
         ?: previousSTEDelay?.let {
             previousCurrentDiff?.let {
@@ -240,7 +254,8 @@ internal fun applyDelay(
     tripId: String,
     stopSequence: Int,
     rdsSchedule: Schedule?,
-    currentDelay: Duration?
+    currentDelay: Duration?,
+    readFromSourceMs: Long
 ): Duration? {
     currentDelay ?: return null
     val rdsTripTimestamp = rdsSchedule?.timestamps?.findClosestTripTimestamp(tripId, stopSequence)
@@ -248,13 +263,16 @@ internal fun applyDelay(
     val currentDiffBetweenArrivalAndDeparture = rdsTripTimestamp.arrivalDiff
     if (currentDelay < Duration.ZERO) {
         rdsTripTimestamp.updateForRealTime(delay = currentDelay, rdsSchedule.providerPrecision, PROVIDER_PRECISION)
+        rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
         return currentDelay // do not consume negative delay
     } else if (currentDiffBetweenArrivalAndDeparture <= currentDelay) {
         val newDelay = (currentDelay - currentDiffBetweenArrivalAndDeparture).coerceAtLeast(Duration.ZERO)
         rdsTripTimestamp.updateForRealTime(arrivalDelay = currentDelay, departureDelay = newDelay, rdsSchedule.providerPrecision, PROVIDER_PRECISION)
+        rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
         return newDelay
     } else {
         rdsTripTimestamp.updateArrivalForRealTime(currentDelay, rdsSchedule.providerPrecision, PROVIDER_PRECISION)
+        rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
         return Duration.ZERO // all delay consumed
     }
 }

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -48,7 +48,7 @@ import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate.Schedu
 
 fun GTFSRealTimeProvider.processRDTripUpdates(
     rdTripUpdates: List<Pair<GTripDescriptor, GTripUpdate>>,
-    targetUuidSchedule: Map<String, Schedule>,
+    rdSchedules: Collection<Schedule>,
     sortedRDS: List<RouteDirectionStop>,
     feedReadFromSourceMs: Long,
     includeCancelledTimestamps: Boolean = false,
@@ -56,17 +56,17 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
     rdTripUpdates.forEach { (td, gTripUpdate) ->
         val gTripId = td.optTripIdNotEmpty ?: return@forEach
         val tripId = parseTripId(gTripId)
-        val tripTargetUuidSchedule = targetUuidSchedule
-            .filter { (_, schedule) -> schedule.hasTripTimestamps(tripId) }
+        val tripSchedules = rdSchedules
+            .filter { schedule -> schedule.hasTripTimestamps(tripId) }
             .takeIf { it.isNotEmpty() }
             ?: return@forEach
         val tripSortedRDS = sortedRDS
-            .filter { rds -> tripTargetUuidSchedule.contains(rds.uuid) }
+            .filter { rds -> tripSchedules.any { it.targetUUID == rds.uuid } }
             .takeIf { it.isNotEmpty() }
             ?: return@forEach
-        val sortedTargetUuidAndSequence = makeTargetUuidAndSequenceList(tripId, tripTargetUuidSchedule, tripSortedRDS)
+        val sortedTargetUuidAndSequence = makeTargetUuidAndSequenceList(tripId, tripSchedules, tripSortedRDS)
         processRDTripUpdate(
-            tripId, gTripUpdate, tripSortedRDS, sortedTargetUuidAndSequence, tripTargetUuidSchedule,
+            tripId, gTripUpdate, tripSortedRDS, sortedTargetUuidAndSequence, tripSchedules,
             isSameStop = { stu, rds, stopSeq -> isSameStop(stu, rds, stopSeq) },
             feedReadFromSourceMs = feedReadFromSourceMs,
             includeCancelledTimestamps = includeCancelledTimestamps,
@@ -76,10 +76,10 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
 
 internal fun makeTargetUuidAndSequenceList(
     tripId: String,
-    tripTargetUuidSchedule: Map<String, Schedule>,
+    tripSchedules: Collection<Schedule>,
     tripSortedRDS: List<RouteDirectionStop>,
 ): List<Pair<String, Int>> {
-    if (tripTargetUuidSchedule.values.any { schedule -> schedule.timestamps.any { it.tripId == tripId && it.stopSequenceOrNull == null } }) {
+    if (tripSchedules.any { schedule -> schedule.timestamps.any { it.tripId == tripId && it.stopSequenceOrNull == null } }) {
         /** should not happen if FF is turned ON [org.mtransit.commons.FeatureFlags.F_EXPORT_STOP_SEQUENCE] */
         return tripSortedRDS
             .mapIndexed { index, rds ->
@@ -89,11 +89,12 @@ internal fun makeTargetUuidAndSequenceList(
     }
     var generatedStopSequence = 1
     return buildSet { // unicity of uuid+sequence
-        tripTargetUuidSchedule.forEach { (targetUuid, schedule) ->
+        tripSchedules.forEach { schedule->
             schedule.getTripTimestamps(tripId).forEach { timestamp ->
-                val stopSequence = timestamp.stopSequenceOrNull ?: generatedStopSequence
-                add(targetUuid to stopSequence)
-                generatedStopSequence = stopSequence + 1 // next probable stop sequence
+                val stopSequence = timestamp.stopSequenceOrNull
+                    ?: generatedStopSequence /** should not happen if FF is turned ON [org.mtransit.commons.FeatureFlags.F_EXPORT_STOP_SEQUENCE] */
+                add(schedule.targetUUID to stopSequence)
+                generatedStopSequence = stopSequence + 1 /** should not happen if FF is turned ON [org.mtransit.commons.FeatureFlags.F_EXPORT_STOP_SEQUENCE] */
             }
         }
     }.sortedBy { (_, stopSequence) -> stopSequence }
@@ -104,18 +105,18 @@ internal fun processRDTripUpdate(
     gTripUpdate: GTripUpdate,
     tripSortedRDS: List<RouteDirectionStop>,
     sortedTargetUuidAndSequence: List<Pair<String, Int>>,
-    tripTargetUuidSchedule: Map<String, Schedule>,
+    tripSchedules: Collection<Schedule>,
     isSameStop: (GTUStopTimeUpdate?, RouteDirectionStop, Int) -> Boolean,
     feedReadFromSourceMs: Long,
     includeCancelledTimestamps: Boolean = false,
 ) {
     val gTripUpdateReadFromSourceMs = gTripUpdate.optTimestampMs ?: feedReadFromSourceMs
     if (gTripUpdate.optTrip?.optScheduleRelationship == GTDScheduleRelationship.DELETED) {
-        tripTargetUuidSchedule.values.setDeleted(tripId, gTripUpdateReadFromSourceMs)
+        tripSchedules.setDeleted(tripId, gTripUpdateReadFromSourceMs)
         return
     }
     if (gTripUpdate.optTrip?.optScheduleRelationship == GTDScheduleRelationship.CANCELED) {
-        tripTargetUuidSchedule.values.setCancelled(tripId, includeCancelledTimestamps, gTripUpdateReadFromSourceMs)
+        tripSchedules.setCancelled(tripId, includeCancelledTimestamps, gTripUpdateReadFromSourceMs)
         return
     }
     if (gTripUpdate.optDelay == null && gTripUpdate.stopTimeUpdateCount == 0) {
@@ -127,41 +128,44 @@ internal fun processRDTripUpdate(
     var currentDelay = gTripUpdate.optDelayDuration // initial delay valid until 1st stop time update
     val gStopTimeUpdates = gTripUpdate.optStopTimeUpdateList?.sortedBy { it.optStopSequence }
     var currentStopTimeUpdate: GTUStopTimeUpdate?
-    var nextStopTimeUpdate: GTUStopTimeUpdate? = gStopTimeUpdates?.getOrNull(stuIdx)
+    var nextStopTimeUpdate = gStopTimeUpdates?.getOrNull(stuIdx)
     var currentUuidAndSeq = sortedTargetUuidAndSequence.getOrNull(uuidAndSeqIdx)
         ?: return // no more stop
-    var currentRDS: RouteDirectionStop = tripSortedRDS.singleOrNull { it.uuid == currentUuidAndSeq.first }
+    var currentRDS = tripSortedRDS.firstOrNull { it.uuid == currentUuidAndSeq.uuid }
         ?: return // stop not found!
     while (uuidAndSeqIdx <= sortedTargetUuidAndSequence.size) {
-        while (!isSameStop(nextStopTimeUpdate, currentRDS, currentUuidAndSeq.second)
+        while (!isSameStop(nextStopTimeUpdate, currentRDS, currentUuidAndSeq.stopSequence)
             && uuidAndSeqIdx <= sortedTargetUuidAndSequence.size // allow null currentRDS to signify end of trip
         ) {
             currentDelay = applyDelay(
                 tripId = tripId,
-                stopSequence = currentUuidAndSeq.second,
-                rdsSchedule = tripTargetUuidSchedule[currentRDS.uuid],
+                stopSequence = currentUuidAndSeq.stopSequence,
+                rdsSchedule = tripSchedules.firstOrNull { it.targetUUID == currentRDS.uuid},
                 currentDelay = currentDelay,
                 readFromSourceMs = gTripUpdateReadFromSourceMs
             )
             currentUuidAndSeq = sortedTargetUuidAndSequence.getOrNull(++uuidAndSeqIdx) ?: break // no more stop
-            currentRDS = tripSortedRDS.singleOrNull { it.uuid == currentUuidAndSeq.first } ?: break // stop not found!
+            currentRDS = tripSortedRDS.firstOrNull { it.uuid == currentUuidAndSeq.uuid } ?: break // stop not found!
         }
         if (uuidAndSeqIdx >= sortedTargetUuidAndSequence.size) break // no more stop
         currentStopTimeUpdate = nextStopTimeUpdate ?: break // no more stop time update
         nextStopTimeUpdate = gStopTimeUpdates?.getOrNull(++stuIdx)
         currentDelay = applyDelaySTU(
             tripId = tripId,
-            stopSequence = currentUuidAndSeq.second,
-            rdsSchedule = tripTargetUuidSchedule[currentRDS.uuid],
+            stopSequence = currentUuidAndSeq.stopSequence,
+            rdsSchedule = tripSchedules.firstOrNull { it.targetUUID == currentRDS.uuid},
             gStopTimeUpdate = currentStopTimeUpdate,
             readFromSourceMs = gTripUpdateReadFromSourceMs,
             currentDelay = currentDelay,
             includeCancelledTimestamps = includeCancelledTimestamps,
         )
         currentUuidAndSeq = sortedTargetUuidAndSequence.getOrNull(++uuidAndSeqIdx) ?: break // no more stop
-        currentRDS = tripSortedRDS.singleOrNull { it.uuid == currentUuidAndSeq.first } ?: break // stop not found!
+        currentRDS = tripSortedRDS.firstOrNull { it.uuid == currentUuidAndSeq.uuid } ?: break // stop not found!
     }
 }
+
+private val Pair<String, Int>.uuid get() = this.first
+private val Pair<String, Int>.stopSequence get() = this.second
 
 fun Iterable<Schedule.Timestamp>.findClosestTripTimestamp(tripId: String, filterStopSequence: Int? = null) =
     this.filter { it.tripId == tripId }

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -150,11 +150,11 @@ internal fun processRDTripUpdate(
                 currentDelay = currentDelay,
                 readFromSourceMs = gTripUpdateReadFromSourceMs
             )
-            currentUuidAndSeq = sortedTargetUuidAndSequence.getOrNull(++uuidAndSeqIdx) ?: break // no more stop
-            currentRDS = tripSortedRDS.firstOrNull { it.uuid == currentUuidAndSeq.uuid } ?: break // stop not found!
+            currentUuidAndSeq = sortedTargetUuidAndSequence.getOrNull(++uuidAndSeqIdx) ?: return // no more stop
+            currentRDS = tripSortedRDS.firstOrNull { it.uuid == currentUuidAndSeq.uuid } ?: return // stop not found!
         }
-        if (uuidAndSeqIdx >= sortedTargetUuidAndSequence.size) break // no more stop
-        currentStopTimeUpdate = nextStopTimeUpdate ?: break // no more stop time update
+        if (uuidAndSeqIdx >= sortedTargetUuidAndSequence.size) return // no more stop
+        currentStopTimeUpdate = nextStopTimeUpdate ?: return // no more stop time update
         nextStopTimeUpdate = gStopTimeUpdates?.getOrNull(++stuIdx)
         currentDelay = applyDelaySTU(
             tripId = tripId,

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -12,6 +12,7 @@ import org.mtransit.android.commons.data.getTripTimestamps
 import org.mtransit.android.commons.data.hasTripTimestamps
 import org.mtransit.android.commons.data.providerPrecision
 import org.mtransit.android.commons.data.setCancelled
+import org.mtransit.android.commons.data.setDeleted
 import org.mtransit.android.commons.data.setReadFromSourceAtInMsKeepMostRecent
 import org.mtransit.android.commons.data.updateArrivalForRealTime
 import org.mtransit.android.commons.data.updateDepartureForRealTime
@@ -110,28 +111,13 @@ internal fun processRDTripUpdate(
     feedReadFromSourceMs: Long,
     includeCancelledTimestamps: Boolean = false,
 ) {
+    val gTripUpdateReadFromSourceMs = gTripUpdate.optTimestampMs ?: feedReadFromSourceMs
     if (gTripUpdate.optTrip?.optScheduleRelationship == GTDScheduleRelationship.DELETED) {
-        tripTargetUuidSchedule.values.forEach { schedule ->
-            val tripTimestamps = schedule.getTripTimestamps(tripId)
-            tripTimestamps.forEach {
-                schedule.removeTimestamp(it)
-            }
-            if (tripTimestamps.isNotEmpty()) {
-                schedule.setReadFromSourceAtInMsKeepMostRecent(gTripUpdate.optTimestampMs ?: feedReadFromSourceMs)
-            }
-        }
+        tripTargetUuidSchedule.values.setDeleted(tripId, gTripUpdateReadFromSourceMs)
         return
     }
     if (gTripUpdate.optTrip?.optScheduleRelationship == GTDScheduleRelationship.CANCELED) {
-        tripTargetUuidSchedule.values.forEach { schedule ->
-            val tripTimestamps = schedule.getTripTimestamps(tripId)
-            tripTimestamps.forEach { timestamp ->
-                schedule.setCancelled(timestamp, true, includeCancelledTimestamps)
-            }
-            if (tripTimestamps.isNotEmpty()) {
-                schedule.setReadFromSourceAtInMsKeepMostRecent(gTripUpdate.optTimestampMs ?: feedReadFromSourceMs)
-            }
-        }
+        tripTargetUuidSchedule.values.setCancelled(tripId, includeCancelledTimestamps, gTripUpdateReadFromSourceMs)
         return
     }
     if (gTripUpdate.optDelay == null && gTripUpdate.stopTimeUpdateCount == 0) {
@@ -157,7 +143,7 @@ internal fun processRDTripUpdate(
                 stopSequence = currentUuidAndSeq.second,
                 rdsSchedule = tripTargetUuidSchedule[currentRDS.uuid],
                 currentDelay = currentDelay,
-                readFromSourceMs = gTripUpdate.optTimestampMs ?: feedReadFromSourceMs
+                readFromSourceMs = gTripUpdateReadFromSourceMs
             )
             currentUuidAndSeq = sortedTargetUuidAndSequence.getOrNull(++uuidAndSeqIdx) ?: break // no more stop
             currentRDS = tripSortedRDS.singleOrNull { it.uuid == currentUuidAndSeq.first } ?: break // stop not found!
@@ -228,7 +214,7 @@ internal fun applyDelaySTU(
     stuDepartureTime?.let { rdsTripTimestamp.updateDepartureForRealTime(newDeparture = it); updated = true }
         ?: stuDepartureDelay?.let { rdsTripTimestamp.updateDepartureForRealTime(it, rdsSchedule.providerPrecision, PROVIDER_PRECISION); updated = true }
     if (gStopTimeUpdate.scheduleRelationship == GTUSTUScheduleRelationship.SKIPPED) {
-        rdsSchedule.setCancelled(rdsTripTimestamp, true, includeCancelledTimestamps)
+        rdsSchedule.setCancelled(rdsTripTimestamp, includeCancelledTimestamps)
         updated = true
     }
     if (updated) rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
@@ -261,20 +247,19 @@ internal fun applyDelay(
     val rdsTripTimestamp = rdsSchedule?.timestamps?.findClosestTripTimestamp(tripId, stopSequence)
         ?: return currentDelay
     val currentDiffBetweenArrivalAndDeparture = rdsTripTimestamp.arrivalDiff
-    if (currentDelay < Duration.ZERO) {
+    val newDelay = if (currentDelay < Duration.ZERO) {
         rdsTripTimestamp.updateForRealTime(delay = currentDelay, rdsSchedule.providerPrecision, PROVIDER_PRECISION)
-        rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
-        return currentDelay // do not consume negative delay
+        currentDelay // do not consume negative delay
     } else if (currentDiffBetweenArrivalAndDeparture <= currentDelay) {
         val newDelay = (currentDelay - currentDiffBetweenArrivalAndDeparture).coerceAtLeast(Duration.ZERO)
         rdsTripTimestamp.updateForRealTime(arrivalDelay = currentDelay, departureDelay = newDelay, rdsSchedule.providerPrecision, PROVIDER_PRECISION)
-        rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
-        return newDelay
+        newDelay
     } else {
         rdsTripTimestamp.updateArrivalForRealTime(currentDelay, rdsSchedule.providerPrecision, PROVIDER_PRECISION)
-        rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
-        return Duration.ZERO // all delay consumed
+        Duration.ZERO // all delay consumed
     }
+    rdsSchedule.setReadFromSourceAtInMsKeepMostRecent(readFromSourceMs)
+    return newDelay
 }
 
 private fun GTFSRealTimeProvider.isSameStop(stopTimeUpdate: GTUStopTimeUpdate?, rds: RouteDirectionStop?, stopSequence: Int) =
@@ -294,5 +279,5 @@ internal fun GTUStopTimeUpdate.isSameStop(
         rds.stop.isSameOriginalId(parseStopId(it))
     }
     if (sameOrUnspecifiedStopSequence == null && sameOrUnspecifiedStopId == null) return false
-    return sameOrUnspecifiedStopSequence != false && sameOrUnspecifiedStopId != false
+    return (sameOrUnspecifiedStopSequence ?: true) && (sameOrUnspecifiedStopId ?: true)
 }

--- a/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
@@ -55,11 +55,13 @@ class GTFSRealTimeTripUpdatesProviderTests {
     fun test_isSameStop() {
         // STU - no stop ID / SEQ filter
         assertFalse { stopTimeUpdate { }.isSameStop(makeRDS(stopId = 1234), 1, parseStopId = { it }) }
+        assertFalse { stopTimeUpdate { }.isSameStop(null, 1, parseStopId = { it }) }
         // STU - stop ID only
         assertTrue { stopTimeUpdate { stopId = "1234" }.isSameStop(makeRDS(stopId = 1234), 1, parseStopId = { it }) }
         assertFalse { stopTimeUpdate { stopId = "1234" }.isSameStop(makeRDS(stopId = 5678), 1, parseStopId = { it }) }
         // STU - stop SEQ only
         assertTrue { stopTimeUpdate { stopSequence = 7 }.isSameStop(makeRDS(stopId = 1234), 7, parseStopId = { it }) }
+        assertFalse { stopTimeUpdate { stopSequence = 1 }.isSameStop(makeRDS(stopId = 1234), 7, parseStopId = { it }) }
         // STU - stop ID & stop SEQ
         assertTrue { stopTimeUpdate { stopId = "1234"; stopSequence = 7 }.isSameStop(makeRDS(stopId = 1234), 7, parseStopId = { it }) }
         assertFalse { stopTimeUpdate { stopId = "1234"; stopSequence = 7 }.isSameStop(makeRDS(stopId = 1234), 1, parseStopId = { it }) }

--- a/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
@@ -346,10 +346,10 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(tripStart)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(tripStart + 10.minutes)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(tripStart + 20.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(tripStart))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(tripStart + 10.minutes))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(tripStart + 20.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -357,21 +357,21 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripSchedule, isSameStop, READ_FROM_MS)
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(tripStart + 1.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(tripStart + 11.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(tripStart + 21.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
@@ -419,17 +419,17 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 9000))
             add(makeRDS(stopId = 10000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
-            rdsList[3].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 30.minutes)))) }
-            rdsList[4].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 43.minutes, arrival = startsAt + 37.minutes)))) }
-            rdsList[5].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 50.minutes)))) }
-            rdsList[6].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 60.minutes)))) }
-            rdsList[7].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 70.minutes)))) }
-            rdsList[8].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 80.minutes)))) }
-            rdsList[9].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 90.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(startsAt + 20.minutes))))
+            add(mkSchedule(rdsList[3].uuid, listOf(mkTime(startsAt + 30.minutes))))
+            add(mkSchedule(rdsList[4].uuid, listOf(mkTime(startsAt + 43.minutes, arrival = startsAt + 37.minutes))))
+            add(mkSchedule(rdsList[5].uuid, listOf(mkTime(startsAt + 50.minutes))))
+            add(mkSchedule(rdsList[6].uuid, listOf(mkTime(startsAt + 60.minutes))))
+            add(mkSchedule(rdsList[7].uuid, listOf(mkTime(startsAt + 70.minutes))))
+            add(mkSchedule(rdsList[8].uuid, listOf(mkTime(startsAt + 80.minutes))))
+            add(mkSchedule(rdsList[9].uuid, listOf(mkTime(startsAt + 90.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -437,64 +437,64 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripSchedule, isSameStop, READ_FROM_MS)
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt, timestamp.arrival)
                 assertEquals(startsAt, timestamp.departure)
                 assertFalse { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 10.minutes, timestamp.arrival)
                 assertEquals(startsAt + 10.minutes + 3.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 20.minutes + 3.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[3].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[3].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 30.minutes + 5.minutes, timestamp.arrival)
                 assertEquals(startsAt + 30.minutes + 5.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[4].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[4].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 37.minutes + 5.minutes, timestamp.arrival)
                 assertEquals(startsAt + 43.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[5].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[5].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 50.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[6].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[6].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[7].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[7].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 70.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[8].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[8].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 80.minutes, timestamp.departure)
                 assertFalse { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[9].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[9].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 90.minutes, timestamp.departure)
                 assertFalse { timestamp.isRealTime }
@@ -544,84 +544,84 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 10000))
         }
         var stopSeq = 0
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt, stopSeq = ++stopSeq)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[3].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 30.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[4].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 43.minutes, stopSeq = ++stopSeq, arrival = startsAt + 37.minutes)))) }
-            rdsList[5].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 50.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[6].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 60.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[7].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 70.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[8].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 80.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[9].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 90.minutes, stopSeq = ++stopSeq)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(startsAt + 20.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[3].uuid, listOf(mkTime(startsAt + 30.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[4].uuid, listOf(mkTime(startsAt + 43.minutes, stopSeq = ++stopSeq, arrival = startsAt + 37.minutes))))
+            add(mkSchedule(rdsList[5].uuid, listOf(mkTime(startsAt + 50.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[6].uuid, listOf(mkTime(startsAt + 60.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[7].uuid, listOf(mkTime(startsAt + 70.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[8].uuid, listOf(mkTime(startsAt + 80.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[9].uuid, listOf(mkTime(startsAt + 90.minutes, stopSeq = ++stopSeq))))
         }
         val sortedTargetUuidAndSequence = buildList {
-            tripTargetUuidSchedule.forEach { (uuid, schedule) ->
+            tripSchedule.forEach { schedule ->
                 schedule.timestamps.forEach { timestamp ->
-                    add(uuid to assertNotNull(timestamp.stopSequenceOrNull))
+                    add(schedule.targetUUID to assertNotNull(timestamp.stopSequenceOrNull))
                 }
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripSchedule, isSameStop, READ_FROM_MS)
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 1.minutes, timestamp.arrival)
                 assertEquals(startsAt + 1.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 10.minutes + 1.minutes, timestamp.arrival)
                 assertEquals(startsAt + 10.minutes + 3.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 20.minutes + 3.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[3].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[3].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 30.minutes + 5.minutes, timestamp.arrival)
                 assertEquals(startsAt + 30.minutes + 5.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[4].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[4].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 37.minutes + 5.minutes, timestamp.arrival)
                 assertEquals(startsAt + 43.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[5].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[5].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 50.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[6].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[6].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[7].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[7].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 70.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[8].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[8].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 80.minutes, timestamp.departure)
                 assertFalse { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[9].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[9].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 90.minutes, timestamp.departure)
                 assertFalse { timestamp.isRealTime }
@@ -670,88 +670,88 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 10000))
         }
         var stopSeq = 0
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt, stopSeq = ++stopSeq)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[3].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 30.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[4].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 43.minutes, stopSeq = ++stopSeq, arrival = startsAt + 37.minutes)))) }
-            rdsList[5].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 50.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[6].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 60.minutes, stopSeq = ++stopSeq)))) }
-            get(rdsList[3].uuid)?.apply {
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(startsAt + 20.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[3].uuid, listOf(mkTime(startsAt + 30.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[4].uuid, listOf(mkTime(startsAt + 43.minutes, stopSeq = ++stopSeq, arrival = startsAt + 37.minutes))))
+            add(mkSchedule(rdsList[5].uuid, listOf(mkTime(startsAt + 50.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[6].uuid, listOf(mkTime(startsAt + 60.minutes, stopSeq = ++stopSeq))))
+            this.singleOrNull { it.targetUUID == rdsList[3].uuid }?.apply {
                 addTimestampWithoutSort(mkTime(startsAt + 70.minutes, stopSeq = ++stopSeq))
                 sortTimestamps()
             }
-            rdsList[7].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 80.minutes, stopSeq = ++stopSeq)))) }
-            rdsList[8].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 90.minutes, stopSeq = ++stopSeq)))) }
+            add(mkSchedule(rdsList[7].uuid, listOf(mkTime(startsAt + 80.minutes, stopSeq = ++stopSeq))))
+            add(mkSchedule(rdsList[8].uuid, listOf(mkTime(startsAt + 90.minutes, stopSeq = ++stopSeq))))
         }
         val sortedTargetUuidAndSequence = buildList {
-            tripTargetUuidSchedule.forEach { (uuid, schedule) ->
+            tripSchedule.forEach { schedule ->
                 schedule.timestamps.forEach { timestamp ->
-                    add(uuid to assertNotNull(timestamp.stopSequenceOrNull))
+                    add(schedule.targetUUID to assertNotNull(timestamp.stopSequenceOrNull))
                 }
             }
         }.sortedBy { (_, stopSequence) -> stopSequence }
 
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripSchedule, isSameStop, READ_FROM_MS)
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 1.minutes, timestamp.arrival)
                 assertEquals(startsAt + 1.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 10.minutes + 1.minutes, timestamp.arrival)
                 assertEquals(startsAt + 10.minutes + 3.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 20.minutes + 3.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[3].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[3].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.getOrNull(0)) { timestamp ->
                 assertEquals(startsAt + 30.minutes + 5.minutes, timestamp.arrival)
                 assertEquals(startsAt + 30.minutes + 5.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[4].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[4].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 37.minutes + 5.minutes, timestamp.arrival)
                 assertEquals(startsAt + 43.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[5].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[5].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 50.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[6].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[6].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[3].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[3].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.getOrNull(1)) { timestamp ->
                 assertEquals(startsAt + 70.minutes, timestamp.departure)
                 assertTrue { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[7].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[7].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 80.minutes, timestamp.departure)
                 assertFalse { timestamp.isRealTime }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[8].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[8].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertEquals(startsAt + 90.minutes, timestamp.departure)
                 assertFalse { timestamp.isRealTime }
@@ -774,10 +774,10 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(startsAt + 20.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -785,15 +785,15 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripSchedule, isSameStop, READ_FROM_MS)
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
     }
@@ -813,10 +813,10 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(startsAt + 20.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -824,15 +824,15 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripSchedule, isSameStop, READ_FROM_MS)
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
     }
@@ -855,10 +855,10 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(startsAt + 20.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -866,19 +866,28 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = true)
+        processRDTripUpdate(
+            TRIP_ID,
+            gTripUpdate,
+            rdsList,
+            sortedTargetUuidAndSequence,
+            tripSchedule,
+            isSameStop,
+            READ_FROM_MS,
+            includeCancelledTimestamps = true
+        )
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertTrue { timestamp.isCancelled }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertTrue { timestamp.isCancelled }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertTrue { timestamp.isCancelled }
             }
@@ -898,9 +907,9 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 1000))
             add(makeRDS(stopId = 2000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -908,12 +917,21 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = false)
+        processRDTripUpdate(
+            TRIP_ID,
+            gTripUpdate,
+            rdsList,
+            sortedTargetUuidAndSequence,
+            tripSchedule,
+            isSameStop,
+            READ_FROM_MS,
+            includeCancelledTimestamps = false
+        )
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
     }
@@ -931,9 +949,9 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 1000))
             add(makeRDS(stopId = 2000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -941,13 +959,22 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = true)
+        processRDTripUpdate(
+            TRIP_ID,
+            gTripUpdate,
+            rdsList,
+            sortedTargetUuidAndSequence,
+            tripSchedule,
+            isSameStop,
+            READ_FROM_MS,
+            includeCancelledTimestamps = true
+        )
 
         // DELETED trips are always removed even when includeCancelledTimestamps = true
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
     }
@@ -969,10 +996,10 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(startsAt + 20.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -980,19 +1007,28 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = true)
+        processRDTripUpdate(
+            TRIP_ID,
+            gTripUpdate,
+            rdsList,
+            sortedTargetUuidAndSequence,
+            tripSchedule,
+            isSameStop,
+            READ_FROM_MS,
+            includeCancelledTimestamps = true
+        )
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertFalse { timestamp.isCancelled }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertTrue { timestamp.isCancelled }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertFalse { timestamp.isCancelled }
             }
@@ -1016,10 +1052,10 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap {
-            rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
-            rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
-            rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
+        val tripSchedule = buildList {
+            add(mkSchedule(rdsList[0].uuid, listOf(mkTime(startsAt))))
+            add(mkSchedule(rdsList[1].uuid, listOf(mkTime(startsAt + 10.minutes))))
+            add(mkSchedule(rdsList[2].uuid, listOf(mkTime(startsAt + 20.minutes))))
         }
         val sortedTargetUuidAndSequence = buildList {
             rdsList.forEachIndexed { index, rds ->
@@ -1027,17 +1063,26 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = false)
+        processRDTripUpdate(
+            TRIP_ID,
+            gTripUpdate,
+            rdsList,
+            sortedTargetUuidAndSequence,
+            tripSchedule,
+            isSameStop,
+            READ_FROM_MS,
+            includeCancelledTimestamps = false
+        )
 
-        assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[0].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertFalse { timestamp.isCancelled }
             }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[1].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[1].uuid }) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
         }
-        assertNotNull(tripTargetUuidSchedule[rdsList[2].uuid]) { schedule ->
+        assertNotNull(tripSchedule.singleOrNull { it.targetUUID == rdsList[2].uuid }) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
                 assertFalse { timestamp.isCancelled }
             }

--- a/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
@@ -43,6 +43,8 @@ class GTFSRealTimeTripUpdatesProviderTests {
 
         private const val NOW_IN_MS = 123456789_000L
 
+        private const val READ_FROM_MS = NOW_IN_MS
+
         private const val TRIP_ID = "123456789"
         private const val STOP_SEQUENCE = 1
     }
@@ -51,12 +53,17 @@ class GTFSRealTimeTripUpdatesProviderTests {
 
     @Test
     fun test_isSameStop() {
+        // STU - no stop ID / SEQ filter
+        assertFalse { stopTimeUpdate { }.isSameStop(makeRDS(stopId = 1234), 1, parseStopId = { it }) }
+        // STU - stop ID only
         assertTrue { stopTimeUpdate { stopId = "1234" }.isSameStop(makeRDS(stopId = 1234), 1, parseStopId = { it }) }
         assertFalse { stopTimeUpdate { stopId = "1234" }.isSameStop(makeRDS(stopId = 5678), 1, parseStopId = { it }) }
-        assertFalse { stopTimeUpdate { }.isSameStop(makeRDS(stopId = 1234), 1, parseStopId = { it }) }
+        // STU - stop SEQ only
         assertTrue { stopTimeUpdate { stopSequence = 7 }.isSameStop(makeRDS(stopId = 1234), 7, parseStopId = { it }) }
-        assertFalse { stopTimeUpdate { }.isSameStop(makeRDS(stopId = 1234), 7, parseStopId = { it }) }
+        // STU - stop ID & stop SEQ
         assertTrue { stopTimeUpdate { stopId = "1234"; stopSequence = 7 }.isSameStop(makeRDS(stopId = 1234), 7, parseStopId = { it }) }
+        assertFalse { stopTimeUpdate { stopId = "1234"; stopSequence = 7 }.isSameStop(makeRDS(stopId = 1234), 1, parseStopId = { it }) }
+        assertFalse { stopTimeUpdate { stopId = "1234"; stopSequence = 7 }.isSameStop(makeRDS(stopId = 5678), 7, parseStopId = { it }) }
         assertFalse { stopTimeUpdate { stopId = "1234"; stopSequence = 7 }.isSameStop(makeRDS(stopId = 5678), 1, parseStopId = { it }) }
     }
 
@@ -70,7 +77,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
         val timestamp = mkTime(departure)
         val delay: Duration? = null
 
-        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay)
+        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay, READ_FROM_MS)
 
         assertNull(result)
         assertFalse { timestamp.isRealTime }
@@ -83,7 +90,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
         val timestamp = mkTime(departure)
         val delay = Duration.ZERO
 
-        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay)
+        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay, READ_FROM_MS)
 
         assertNotNull(result)
         assertEquals(delay, result) // delay not consumed
@@ -97,7 +104,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
         val timestamp = mkTime(departure)
         val delay = 10.minutes
 
-        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay)
+        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay, READ_FROM_MS)
 
         assertNotNull(result)
         assertEquals(delay, result) // delay not consumed
@@ -112,7 +119,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
         val timestamp = mkTime(departure, arrival = arrival)
         val delay = 10.minutes
 
-        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay)
+        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay, READ_FROM_MS)
 
         assertNotNull(result)
         assertEquals(9.minutes, result) // delay partially consumed
@@ -128,7 +135,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
         val timestamp = mkTime(departure, arrival = arrival)
         val delay = 10.minutes
 
-        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay)
+        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay, READ_FROM_MS)
 
         assertNotNull(result)
         assertEquals(Duration.ZERO, result) // delay consumed
@@ -144,7 +151,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
         val timestamp = mkTime(departure, arrival = arrival)
         val delay = (-5).minutes
 
-        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay)
+        val result = applyDelay(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), delay, READ_FROM_MS)
 
         assertNotNull(result)
         assertEquals(delay, result) // delay not consumed
@@ -167,7 +174,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate)
+        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate, READ_FROM_MS)
 
         assertNotNull(result)
         assertEquals(1.minutes, result)
@@ -192,7 +199,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate)
+        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate, READ_FROM_MS)
 
         assertNotNull(result)
         assertEquals(2.minutes, result)
@@ -215,7 +222,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate)
+        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate, READ_FROM_MS)
 
         assertNotNull(result)
         assertEquals(2.minutes, result)
@@ -236,7 +243,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate, delay)
+        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate, READ_FROM_MS, delay)
 
         assertNotNull(result)
         assertEquals(2.minutes, result)
@@ -257,7 +264,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate, delay)
+        val result = applyDelaySTU(TRIP_ID, STOP_SEQUENCE, timestamp.toSchedule(), stopTimeUpdate, READ_FROM_MS, delay)
 
         assertNotNull(result)
         assertEquals(2.minutes, result)
@@ -337,7 +344,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(tripStart)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(tripStart + 10.minutes)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(tripStart + 20.minutes)))) }
@@ -348,7 +355,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
@@ -410,7 +417,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 9000))
             add(makeRDS(stopId = 10000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
@@ -428,7 +435,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
@@ -535,7 +542,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 10000))
         }
         var stopSeq = 0
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt, stopSeq = ++stopSeq)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes, stopSeq = ++stopSeq)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes, stopSeq = ++stopSeq)))) }
@@ -549,13 +556,13 @@ class GTFSRealTimeTripUpdatesProviderTests {
         }
         val sortedTargetUuidAndSequence = buildList {
             tripTargetUuidSchedule.forEach { (uuid, schedule) ->
-                schedule?.timestamps?.forEach { timestamp ->
+                schedule.timestamps.forEach { timestamp ->
                     add(uuid to assertNotNull(timestamp.stopSequenceOrNull))
                 }
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
@@ -661,7 +668,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 10000))
         }
         var stopSeq = 0
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt, stopSeq = ++stopSeq)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes, stopSeq = ++stopSeq)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes, stopSeq = ++stopSeq)))) }
@@ -678,14 +685,14 @@ class GTFSRealTimeTripUpdatesProviderTests {
         }
         val sortedTargetUuidAndSequence = buildList {
             tripTargetUuidSchedule.forEach { (uuid, schedule) ->
-                schedule?.timestamps?.forEach { timestamp ->
+                schedule.timestamps.forEach { timestamp ->
                     add(uuid to assertNotNull(timestamp.stopSequenceOrNull))
                 }
             }
         }.sortedBy { (_, stopSequence) -> stopSequence }
 
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
@@ -765,7 +772,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
@@ -776,7 +783,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
@@ -804,7 +811,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
@@ -815,7 +822,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
@@ -846,7 +853,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
@@ -857,7 +864,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, includeCancelledTimestamps = true)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = true)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
@@ -889,7 +896,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 1000))
             add(makeRDS(stopId = 2000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
         }
@@ -899,7 +906,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, includeCancelledTimestamps = false)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = false)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertTrue { schedule.timestamps.isEmpty() }
@@ -922,7 +929,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 1000))
             add(makeRDS(stopId = 2000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
         }
@@ -932,7 +939,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, includeCancelledTimestamps = true)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = true)
 
         // DELETED trips are always removed even when includeCancelledTimestamps = true
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
@@ -960,7 +967,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
@@ -971,7 +978,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, includeCancelledTimestamps = true)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = true)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->
@@ -1007,7 +1014,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             add(makeRDS(stopId = 2000))
             add(makeRDS(stopId = 3000))
         }
-        val tripTargetUuidSchedule = buildMap<String, Schedule?> {
+        val tripTargetUuidSchedule = buildMap {
             rdsList[0].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt)))) }
             rdsList[1].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 10.minutes)))) }
             rdsList[2].uuid.let { put(it, mkSchedule(it, listOf(mkTime(startsAt + 20.minutes)))) }
@@ -1018,7 +1025,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
             }
         }
 
-        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, includeCancelledTimestamps = false)
+        processRDTripUpdate(TRIP_ID, gTripUpdate, rdsList, sortedTargetUuidAndSequence, tripTargetUuidSchedule, isSameStop, READ_FROM_MS, includeCancelledTimestamps = false)
 
         assertNotNull(tripTargetUuidSchedule[rdsList[0].uuid]) { schedule ->
             assertNotNull(schedule.timestamps.singleOrNull()) { timestamp ->


### PR DESCRIPTION
Sometimes, the GTFS-RT Trip Updates feeds contain multiple Trip Updates for the same `trip_id` ⚠️  and some of them do not match static `stop_times.txt` `trip_id` `stop_id` & `stop_sequence`.

-> we need stricter "same stop" matching for RT Stop Time Updates and static stop_times

This issue was found while debugging https://github.com/mtransitapps/ca-edmonton-ets-bus-android