### PR TITLE
GTFS-RT Trip Updates > fix static data used too small.

### DIFF
--- a/src/main/java/org/mtransit/android/commons/data/Schedule.java
+++ b/src/main/java/org/mtransit/android/commons/data/Schedule.java
@@ -27,6 +27,7 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("WeakerAccess")
+// aka. [route+direction+stop]>trips>stop_times
 public class Schedule extends POIStatus implements MTLog.Loggable {
 
 	private static final String LOG_TAG = Schedule.class.getSimpleName();

--- a/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsStatusProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/gtfs/GtfsStatusProviderExt.kt
@@ -11,8 +11,9 @@ import org.mtransit.android.commons.provider.status.StatusProviderContract
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 
-private const val DEFAULT_MAX_DATA_REQUEST = 3 // yesterday service ending + today + tomorrow?
-private val DEFAULT_LOOK_BEHIND = 1.hours
+// SAME as regular schedule status fetch from UI since cached is shared
+private const val DEFAULT_MAX_DATA_REQUEST = ScheduleStatusFilter.MAX_DATA_REQUESTS_DEFAULT // same as UI-trigger fetch (shared cache)
+private val DEFAULT_LOOK_BEHIND = 1.hours // same as UI-trigger fetch (shared cache)
 
 fun Context.getRDSSchedule(
     authority: String,

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -216,7 +216,7 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
                 feedReadFromSourceMs = feedReadFromSourceMs,
                 includeCancelledTimestamps = filter.isIncludeCancelledTimestampsOrDefault,
             )
-            cacheRealTimeSchedules(scheduleList = rdSchedules, sourceLabel = sourceLabel, lastUpdateInMs = lastUpdateInMs)
+            cacheRealTimeSchedules(rdSchedules = rdSchedules, sourceLabel = sourceLabel, lastUpdateInMs = lastUpdateInMs)
             return getCachedStatusS(filter.targetUUID, staticRDTripIds)
         } catch (e: Exception) {
             MTLog.w(LOG_TAG, e, "makeCachedStatusFromAgencyData() > error!")
@@ -270,51 +270,52 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
     private const val MIN_NUMBER_OF_FUTURE_FOR_REAL_TIME = 10 // need to keep multiple RT timestamps to be able to show the next non-RT is in a long time
 
     private fun GTFSRealTimeProvider.cacheRealTimeSchedules(
-        scheduleList: Collection<Schedule>,
+        rdSchedules: Collection<Schedule>,
         sourceLabel: String,
         lastUpdateInMs: Long,
         ignorePastRealTime: Boolean = false,
-        tripsWithRealTime: Set<String> = scheduleList
+        tripsWithRealTime: Set<String> = rdSchedules
             .asSequence()
-            .mapNotNull { schedule -> schedule.timestamps.takeIf { it.isNotEmpty() } }.flatten()
+            .mapNotNull { schedule -> schedule.timestamps.takeIf { it.isNotEmpty() } }
+            .flatten()
             .filter { it.isRealTimeOrCancelled }
             .mapNotNull { it.tripId }
             .toSet() // distinct
     ) {
-        scheduleList.forEach { schedule ->
-            schedule.sourceLabel = sourceLabel
-            schedule.lastUpdateInMs = lastUpdateInMs
-            schedule.providerPrecisionInMs = PROVIDER_PRECISION_IN_MS
-            schedule.maxValidityInMs = statusMaxValidityInMs
+        rdSchedules.forEach { rdsSchedule ->
+            rdsSchedule.sourceLabel = sourceLabel
+            rdsSchedule.lastUpdateInMs = lastUpdateInMs
+            rdsSchedule.providerPrecisionInMs = PROVIDER_PRECISION_IN_MS
+            rdsSchedule.maxValidityInMs = statusMaxValidityInMs
             val now = TimeUtilsK.currentInstant()
-            if (!schedule.timestamps.any { it.isRealTimeOrCancelled || (it.tripId in tripsWithRealTime && it.departure < now) }) {
-                cacheStatus(schedule.toNoData()) // avoid re-run
+            if (rdsSchedule.timestamps.none { it.isRealTimeOrCancelled || (it.tripId in tripsWithRealTime && it.departure < now) }) {
+                cacheStatus(rdsSchedule.toNoData()) // avoid re-run
                 return@forEach
             }
             var oldestDateForRealTime = now - OLDEST_FOR_REAL_TIME
             var maxFutureDateForRealTime = now + MAX_FUTURE_FOR_REAL_TIME
-            val (past, future) = schedule.timestamps.partition { it.departure < now }
+            val (sortedPastTimestamps, sortedFutureTimestamps) = rdsSchedule.timestamps.partition { it.departure < now }
             if (!ignorePastRealTime) {
-                oldestDateForRealTime = past.filter { it.isRealTimeOrCancelled }.minOfOrNull { it.arrival } // all real-time
+                oldestDateForRealTime = sortedPastTimestamps.filter { it.isRealTimeOrCancelled }.minOfOrNull { it.arrival } // all real-time
                     ?: oldestDateForRealTime
             }
-            future.take(MIN_NUMBER_OF_FUTURE_FOR_REAL_TIME).maxOfOrNull { it.departure }
+            sortedFutureTimestamps.take(MIN_NUMBER_OF_FUTURE_FOR_REAL_TIME).maxOfOrNull { it.departure }
                 ?.takeIf { it > maxFutureDateForRealTime }
                 ?.let {
                     maxFutureDateForRealTime = it
                 }
-            future.filter { it.isRealTimeOrCancelled }.maxOfOrNull { it.departure } // all real-time
+            sortedFutureTimestamps.filter { it.isRealTimeOrCancelled }.maxOfOrNull { it.departure } // all real-time
                 ?.takeIf { it > maxFutureDateForRealTime }
                 ?.let {
                     maxFutureDateForRealTime = it
                 }
             // remove timestamps that are not real-time & outside of min/max date for real-time
-            schedule.timestamps
+            rdsSchedule.timestamps
                 .filterNot {
                     it.isRealTimeOrCancelled || oldestDateForRealTime < it.arrival && it.departure < maxFutureDateForRealTime
                 }
-                .forEach { schedule.removeTimestamp(it) }
-            cacheStatus(schedule)
+                .forEach { rdsSchedule.removeTimestamp(it) }
+            cacheStatus(rdsSchedule)
         }
     }
 

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -53,12 +53,14 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
     includeCancelledTimestamps: Boolean = false,
 ) {
     val rdSchedulesByUUID = rdSchedules.associateBy { it.targetUUID }
-    val rdsUUIDsByTripId = mutableMapOf<String, MutableSet<String>>()
-    rdSchedulesByUUID.forEach { (uuid, schedule) ->
-        schedule.timestamps.mapNotNull { it.tripId }.forEach { tripId ->
-            rdsUUIDsByTripId.getOrPut(tripId) { mutableSetOf() }.add(uuid)
+    val rdsUUIDsByTripId = rdSchedules
+        .flatMap { schedule ->
+            schedule.timestamps
+                .mapNotNull { it.tripId }
+                .map { tripId -> tripId to schedule.targetUUID }
         }
-    }
+        .groupBy({ it.first }, { it.second })
+        .mapValues { (_, uuids) -> uuids.toSet() }
     rdTripUpdates.forEach { (td, gTripUpdate) ->
         val gTripId = td.optTripIdNotEmpty ?: return@forEach
         val tripId = parseTripId(gTripId)
@@ -72,14 +74,14 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
         val sortedTargetUuidAndSequence = makeTargetUuidAndSequenceList(tripId, tripSchedules, tripSortedRDS)
         processRDTripUpdate(
             tripId, gTripUpdate, tripSortedRDS, sortedTargetUuidAndSequence, rdSchedulesByUUID,
-            isSameStop = { stu, rds, stopSeq -> isSameStop(stu, rds, stopSeq) },
+            isSameStop = this::isSameStop,
             feedReadFromSourceMs = feedReadFromSourceMs,
             fixStopSequence = {
                 it?.fixStopSequence(
                     tripId = tripId,
                     tripSortedRDS = tripSortedRDS,
                     sortedTargetUuidAndSequence = sortedTargetUuidAndSequence,
-                    isSameStop = { stu, rds, stopSeq -> isSameStop(stu, rds, stopSeq) },
+                    isSameStop = this::isSameStop,
                     parseStopId = this::parseStopId,
                 )
             },

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -52,28 +52,22 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
     feedReadFromSourceMs: Long,
     includeCancelledTimestamps: Boolean = false,
 ) {
-    val schedulesByTripId = mutableMapOf<String, MutableSet<Schedule>>()
-    rdSchedules.forEach { schedule ->
-        schedule.timestamps.forEach { timestamp ->
-            timestamp.tripId?.let { tripId ->
-                schedulesByTripId.getOrPut(tripId) { mutableSetOf() }.add(schedule)
-            }
-        }
-    }
+    val rdSchedulesByUUID = rdSchedules.associateBy { it.targetUUID }
     rdTripUpdates.forEach { (td, gTripUpdate) ->
         val gTripId = td.optTripIdNotEmpty ?: return@forEach
         val tripId = parseTripId(gTripId)
-        val tripSchedulesByUUID = schedulesByTripId[tripId]
-            ?.takeIf { it.isNotEmpty() }
-            ?.associateBy { it.targetUUID }
-            ?: return@forEach
+        if (rdSchedulesByUUID.none { (_, schedule) -> schedule.timestamps.any { it.tripId == tripId } })
+            return@forEach // trip ID not in static data
+        val tripRdsUUIDs = rdSchedulesByUUID
+            .filter { (_, schedule) -> schedule.timestamps.any { it.tripId == tripId } }
+            .keys
         val tripSortedRDS = sortedRDS
-            .filter { rds -> rds.uuid in tripSchedulesByUUID.keys }
+            .filter { rds -> rds.uuid in tripRdsUUIDs }
             .takeIf { it.isNotEmpty() }
             ?: return@forEach
-        val sortedTargetUuidAndSequence = makeTargetUuidAndSequenceList(tripId, tripSchedulesByUUID.values, tripSortedRDS)
+        val sortedTargetUuidAndSequence = makeTargetUuidAndSequenceList(tripId, rdSchedulesByUUID.values, tripSortedRDS)
         processRDTripUpdate(
-            tripId, gTripUpdate, tripSortedRDS, sortedTargetUuidAndSequence, tripSchedulesByUUID,
+            tripId, gTripUpdate, tripSortedRDS, sortedTargetUuidAndSequence, rdSchedulesByUUID,
             isSameStop = { stu, rds, stopSeq -> isSameStop(stu, rds, stopSeq) },
             feedReadFromSourceMs = feedReadFromSourceMs,
             fixStopSequence = {

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -118,7 +118,7 @@ internal fun processRDTripUpdate(
     gTripUpdate: GTripUpdate,
     tripSortedRDS: List<RouteDirectionStop>,
     sortedTargetUuidAndSequence: List<Pair<String, Int>>,
-    tripSchedulesByUUID: Map<String, Schedule>,
+    rdSchedulesByUUID: Map<String, Schedule>,
     isSameStop: (GTUStopTimeUpdate?, RouteDirectionStop, Int) -> Boolean,
     feedReadFromSourceMs: Long,
     fixStopSequence: (List<GTUStopTimeUpdate>?) -> List<GTUStopTimeUpdate>? = { it },
@@ -126,11 +126,11 @@ internal fun processRDTripUpdate(
 ) {
     val gTripUpdateReadFromSourceMs = gTripUpdate.optTimestampMs ?: feedReadFromSourceMs
     if (gTripUpdate.optTrip?.optScheduleRelationship == GTDScheduleRelationship.DELETED) {
-        tripSchedulesByUUID.values.setTripDeleted(tripId, gTripUpdateReadFromSourceMs)
+        rdSchedulesByUUID.values.setTripDeleted(tripId, gTripUpdateReadFromSourceMs)
         return
     }
     if (gTripUpdate.optTrip?.optScheduleRelationship == GTDScheduleRelationship.CANCELED) {
-        tripSchedulesByUUID.values.setTripCancelled(tripId, includeCancelledTimestamps, gTripUpdateReadFromSourceMs)
+        rdSchedulesByUUID.values.setTripCancelled(tripId, includeCancelledTimestamps, gTripUpdateReadFromSourceMs)
         return
     }
     if (gTripUpdate.optDelay == null && gTripUpdate.stopTimeUpdateCount == 0) {
@@ -155,7 +155,7 @@ internal fun processRDTripUpdate(
             currentDelay = applyDelay(
                 tripId = tripId,
                 stopSequence = currentUuidAndSeq.stopSequence,
-                rdsSchedule = tripSchedulesByUUID[currentRDS.uuid],
+                rdsSchedule = rdSchedulesByUUID[currentRDS.uuid],
                 currentDelay = currentDelay,
                 readFromSourceMs = gTripUpdateReadFromSourceMs
             )
@@ -168,7 +168,7 @@ internal fun processRDTripUpdate(
         currentDelay = applyDelaySTU(
             tripId = tripId,
             stopSequence = currentUuidAndSeq.stopSequence,
-            rdsSchedule = tripSchedulesByUUID[currentRDS.uuid],
+            rdsSchedule = rdSchedulesByUUID[currentRDS.uuid],
             gStopTimeUpdate = currentStopTimeUpdate,
             readFromSourceMs = gTripUpdateReadFromSourceMs,
             currentDelay = currentDelay,

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderExt.kt
@@ -53,19 +53,23 @@ fun GTFSRealTimeProvider.processRDTripUpdates(
     includeCancelledTimestamps: Boolean = false,
 ) {
     val rdSchedulesByUUID = rdSchedules.associateBy { it.targetUUID }
+    val rdsUUIDsByTripId = mutableMapOf<String, MutableSet<String>>()
+    rdSchedulesByUUID.forEach { (uuid, schedule) ->
+        schedule.timestamps.mapNotNull { it.tripId }.forEach { tripId ->
+            rdsUUIDsByTripId.getOrPut(tripId) { mutableSetOf() }.add(uuid)
+        }
+    }
     rdTripUpdates.forEach { (td, gTripUpdate) ->
         val gTripId = td.optTripIdNotEmpty ?: return@forEach
         val tripId = parseTripId(gTripId)
-        if (rdSchedulesByUUID.none { (_, schedule) -> schedule.timestamps.any { it.tripId == tripId } })
-            return@forEach // trip ID not in static data
-        val tripRdsUUIDs = rdSchedulesByUUID
-            .filter { (_, schedule) -> schedule.timestamps.any { it.tripId == tripId } }
-            .keys
+        val tripRdsUUIDs = rdsUUIDsByTripId[tripId]
+            ?: return@forEach // trip ID not in static data
+        val tripSchedules = tripRdsUUIDs.mapNotNull { rdSchedulesByUUID[it] }
         val tripSortedRDS = sortedRDS
             .filter { rds -> rds.uuid in tripRdsUUIDs }
             .takeIf { it.isNotEmpty() }
             ?: return@forEach
-        val sortedTargetUuidAndSequence = makeTargetUuidAndSequenceList(tripId, rdSchedulesByUUID.values, tripSortedRDS)
+        val sortedTargetUuidAndSequence = makeTargetUuidAndSequenceList(tripId, tripSchedules, tripSortedRDS)
         processRDTripUpdate(
             tripId, gTripUpdate, tripSortedRDS, sortedTargetUuidAndSequence, rdSchedulesByUUID,
             isSameStop = { stu, rds, stopSeq -> isSameStop(stu, rds, stopSeq) },


### PR DESCRIPTION
Max 3 days is not enough to make sure we always have 2 next departures (incl. far away static)

(bug of Friday PM with routes service ending on Friday before Week-End breaks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching and processing of real-time trip updates against scheduled transit data for more consistent results.
  * Refined schedule caching and timestamp handling, including when to avoid redundant “no data” refreshes.
  * Updated GTFS schedule status request/caching parameters to align with the default fetch behaviour.
* **Documentation**
  * Added clarification on how schedule timestamps are sourced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->