### PR TITLE
GTFS-RT Trip Updates > filter duplicate unique trip updates #TripModifications

### DIFF
--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilter.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilter.kt
@@ -1,6 +1,7 @@
 package org.mtransit.android.commons.provider.status
 
 import org.mtransit.android.commons.MTLog
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optModifiedTrip
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStartDate
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStartTime
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
@@ -9,9 +10,11 @@ import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
 import org.mtransit.android.commons.provider.status.GTFSRealTimeTripUpdatesProvider.LOG_TAG
 import com.google.transit.realtime.GtfsRealtime.TripUpdate as GTripUpdate
 
-fun List<GTripUpdate>.filterDuplicatesTrips() = buildList<GTripUpdate> {
+internal fun List<GTripUpdate>.filterDuplicatesTrips() = buildList<GTripUpdate> {
     this@filterDuplicatesTrips.groupBy {
-        it.optTrip?.optTripIdNotEmpty to (it.optTrip?.optStartDate to it.optTrip?.optStartTime)
+        it.optTrip?.optTripIdNotEmpty to (
+                (it.optTrip?.optStartDate ?: it.optTrip?.optModifiedTrip?.optStartDate) to
+                        (it.optTrip?.optStartTime ?: it.optTrip?.optModifiedTrip?.optStartTime))
     }.forEach { (_, gTripUpdates) ->
         if (gTripUpdates.isEmpty()) return@forEach
         if (gTripUpdates.size == 1) {
@@ -20,7 +23,6 @@ fun List<GTripUpdate>.filterDuplicatesTrips() = buildList<GTripUpdate> {
             return@forEach
         }
         // PICK ONE
-        }
         // 1 - pick one w/o ModifiedTrip AND w/ Vehicle descriptor
         gTripUpdates
             .filter { it.optTrip?.hasModifiedTrip() == false && it.hasVehicle() }

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilter.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilter.kt
@@ -4,11 +4,9 @@ import org.mtransit.android.commons.MTLog
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStartDate
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStartTime
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
-import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTripId
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTripIdNotEmpty
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
 import org.mtransit.android.commons.provider.status.GTFSRealTimeTripUpdatesProvider.LOG_TAG
-import com.google.transit.realtime.GtfsRealtime.TripDescriptor as GTripDescriptor
 import com.google.transit.realtime.GtfsRealtime.TripUpdate as GTripUpdate
 
 fun List<GTripUpdate>.filterDuplicatesTrips() = buildList<GTripUpdate> {
@@ -22,12 +20,30 @@ fun List<GTripUpdate>.filterDuplicatesTrips() = buildList<GTripUpdate> {
             return@forEach
         }
         // PICK ONE
-        // 1 - pick one w/o ModifiedTrip
-        gTripUpdates.singleOrNull { it.optTrip?.hasModifiedTrip() == false }?.let { gTripUpdate ->
-            MTLog.d(LOG_TAG, "filterDuplicatesTrips() > pick 1 out of ${gTripUpdates.size} w/o ModifiedTrip: ${gTripUpdate.toStringExt()}")
-            add(gTripUpdate)
-            return@forEach
         }
+        // 1 - pick one w/o ModifiedTrip AND w/ Vehicle descriptor
+        gTripUpdates
+            .filter { it.optTrip?.hasModifiedTrip() == false && it.hasVehicle() }
+            .takeIf { it.isNotEmpty() }
+            ?.let { woModifiedTripAndWVehicle ->
+                val picked = woModifiedTripAndWVehicle.first()
+                MTLog.d(
+                    LOG_TAG,
+                    "filterDuplicatesTrips() > pick 1st out of ${woModifiedTripAndWVehicle.size} w/o ModifiedTrip and w/ Vehicle: ${picked.toStringExt()}"
+                )
+                add(picked)
+                return@forEach
+            }
+        // 2 - pick one w/o ModifiedTrip
+        gTripUpdates
+            .filter { it.optTrip?.hasModifiedTrip() == false }
+            .takeIf { it.isNotEmpty() }
+            ?.let { woModifiedTrip ->
+                val picked = woModifiedTrip.first()
+                MTLog.d(LOG_TAG, "filterDuplicatesTrips() > pick 1st out of ${woModifiedTrip.size} w/o ModifiedTrip: ${picked.toStringExt()}")
+                add(picked)
+                return@forEach
+            }
         // ELSE -> pick 1st one in the list
         val gTripUpdate1 = gTripUpdates.firstOrNull() ?: return@forEach
         MTLog.d(LOG_TAG, "filterDuplicatesTrips() > use 1st one out of ${gTripUpdates.size}: ${gTripUpdate1.toStringExt()}")

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilter.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilter.kt
@@ -46,6 +46,16 @@ internal fun List<GTripUpdate>.filterDuplicatesTrips() = buildList<GTripUpdate> 
                 add(picked)
                 return@forEach
             }
+        // 3 - pick one w/ Vehicle descriptor (even if it has ModifiedTrip)
+        gTripUpdates
+            .filter { it.hasVehicle() }
+            .takeIf { it.isNotEmpty() }
+            ?.let { wVehicle ->
+                val picked = wVehicle.first()
+                MTLog.d(LOG_TAG, "filterDuplicatesTrips() > pick 1st out of ${wVehicle.size} w/ Vehicle: ${picked.toStringExt()}")
+                add(picked)
+                return@forEach
+            }
         // ELSE -> pick 1st one in the list
         val gTripUpdate1 = gTripUpdates.firstOrNull() ?: return@forEach
         MTLog.d(LOG_TAG, "filterDuplicatesTrips() > use 1st one out of ${gTripUpdates.size}: ${gTripUpdate1.toStringExt()}")

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilter.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilter.kt
@@ -1,0 +1,36 @@
+package org.mtransit.android.commons.provider.status
+
+import org.mtransit.android.commons.MTLog
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStartDate
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStartTime
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTrip
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTripId
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTripIdNotEmpty
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.toStringExt
+import org.mtransit.android.commons.provider.status.GTFSRealTimeTripUpdatesProvider.LOG_TAG
+import com.google.transit.realtime.GtfsRealtime.TripDescriptor as GTripDescriptor
+import com.google.transit.realtime.GtfsRealtime.TripUpdate as GTripUpdate
+
+fun List<GTripUpdate>.filterDuplicatesTrips() = buildList<GTripUpdate> {
+    this@filterDuplicatesTrips.groupBy {
+        it.optTrip?.optTripIdNotEmpty to (it.optTrip?.optStartDate to it.optTrip?.optStartTime)
+    }.forEach { (_, gTripUpdates) ->
+        if (gTripUpdates.isEmpty()) return@forEach
+        if (gTripUpdates.size == 1) {
+            val gTripUpdate1 = gTripUpdates.firstOrNull() ?: return@forEach
+            add(gTripUpdate1)
+            return@forEach
+        }
+        // PICK ONE
+        // 1 - pick one w/o ModifiedTrip
+        gTripUpdates.singleOrNull { it.optTrip?.hasModifiedTrip() == false }?.let { gTripUpdate ->
+            MTLog.d(LOG_TAG, "filterDuplicatesTrips() > pick 1 out of ${gTripUpdates.size} w/o ModifiedTrip: ${gTripUpdate.toStringExt()}")
+            add(gTripUpdate)
+            return@forEach
+        }
+        // ELSE -> pick 1st one in the list
+        val gTripUpdate1 = gTripUpdates.firstOrNull() ?: return@forEach
+        MTLog.d(LOG_TAG, "filterDuplicatesTrips() > use 1st one out of ${gTripUpdates.size}: ${gTripUpdate1.toStringExt()}")
+        add(gTripUpdate1)
+    }
+}

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -2,6 +2,7 @@ package org.mtransit.android.commons.provider.status
 
 import android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.google.transit.realtime.headerOrNull
 import org.mtransit.android.commons.Constants
 import org.mtransit.android.commons.MTLog
@@ -151,15 +152,17 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
             val rdTripUpdates = gTripUpdates
                 .filter { it.isUseful() }
                 .filter { gTripUpdate ->
-                    match(
-                        td = gTripUpdate.optTrip ?: return@filter false,
+                    gTripUpdate.optTrip?.match(
                         targetRouteIdHash = targetRouteIdHash,
                         targetDirectionOriginalId = targetDirectionOriginalId,
                         staticRDTripIds = staticRDTripIds,
+                        ignoreDirection = ignoreDirection,
+                        parseRouteId = ::parseRouteId,
+                        parseTripId = ::parseTripId,
                         setTripIdsOutOfSync = {
                             tripIdsOutOfSync = it
                         },
-                    )
+                    ) == true
                 }
                 .filterDuplicatesTrips()
                 .takeIf { it.isNotEmpty() }
@@ -225,14 +228,17 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
         }
     }
 
-    private fun GTFSRealTimeProvider.match(
-        td: GTripDescriptor,
+    @VisibleForTesting
+    internal fun GTripDescriptor.match(
         targetRouteIdHash: String,
         targetDirectionOriginalId: Int?,
         staticRDTripIds: Set<String>,
+        ignoreDirection: Boolean,
+        parseRouteId: (GTripDescriptor) -> String?,
+        parseTripId: (GTripDescriptor) -> String?,
         setTripIdsOutOfSync: (Boolean) -> Unit,
     ): Boolean {
-        parseRouteId(td)?.let { rtRouteIdHash ->
+        parseRouteId(this)?.let { rtRouteIdHash ->
             if (rtRouteIdHash != targetRouteIdHash) {
                 // if (DEBUG_STATIC_RT_MATCH) { // too much log
                 // MTLog.d(LOG_TAG, "match() > IGNORE: wrong route ID '$rtRouteIdHash' (t:$targetRouteIdHash)")
@@ -241,24 +247,24 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
             }
         }
         @Suppress("SimplifyBooleanWithConstants")
-        if (!ALLOW_IGNORE_TRIP_DESCRIPTOR_DIRECTION_ID || td.optTripIdNotEmpty == null) {
-            td.optDirectionIdValid?.takeIf { !ignoreDirection }?.let { directionId ->
+        if (!ALLOW_IGNORE_TRIP_DESCRIPTOR_DIRECTION_ID || optTripIdNotEmpty == null) {
+            optDirectionIdValid?.takeIf { !ignoreDirection }?.let { directionId ->
                 if (directionId != targetDirectionOriginalId) {
                     if (DEBUG_STATIC_RT_MATCH) {
                         MTLog.d(
                             LOG_TAG,
-                            "match() > IGNORE: wrong direction ID '$directionId' for ${td.toStringExt(short = true)}"
+                            "match() > IGNORE: wrong direction ID '$directionId' for ${toStringExt(short = true)}"
                         )
                     }
                     return false // NOT A MATCH
                 }
             }
         }
-        parseTripId(td)?.let { tripId ->
+        parseTripId(this)?.let { tripId ->
             if (tripId !in staticRDTripIds) {
-                if (td.hasRouteId()) {
+                if (hasRouteId()) {
                     if (DEBUG_STATIC_RT_MATCH) {
-                        MTLog.d(LOG_TAG, "match() > IGNORE: wrong trip ID ($tripId) for ${td.toStringExt(short = true)}")
+                        MTLog.d(LOG_TAG, "match() > IGNORE: wrong trip ID ($tripId) for ${toStringExt(short = true)}")
                     }
                     setTripIdsOutOfSync(true)
                 }

--- a/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
+++ b/src/main/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProvider.kt
@@ -150,11 +150,9 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
             }
             val rdTripUpdates = gTripUpdates
                 .filter { it.isUseful() }
-                .mapNotNull { gTripUpdate ->
-                    gTripUpdate.optTrip?.let { it to gTripUpdate }
-                }.filter { (td, _) ->
+                .filter { gTripUpdate ->
                     match(
-                        td = td,
+                        td = gTripUpdate.optTrip ?: return@filter false,
                         targetRouteIdHash = targetRouteIdHash,
                         targetDirectionOriginalId = targetDirectionOriginalId,
                         staticRDTripIds = staticRDTripIds,
@@ -162,7 +160,10 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
                             tripIdsOutOfSync = it
                         },
                     )
-                }.takeIf { it.isNotEmpty() }
+                }
+                .filterDuplicatesTrips()
+                .takeIf { it.isNotEmpty() }
+                ?.mapNotNull { gTripUpdate -> gTripUpdate.optTrip?.let { it to gTripUpdate } }
             if (tripIdsOutOfSync) {
                 MTLog.i(
                     LOG_TAG,
@@ -234,7 +235,7 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
         parseRouteId(td)?.let { rtRouteIdHash ->
             if (rtRouteIdHash != targetRouteIdHash) {
                 // if (DEBUG_STATIC_RT_MATCH) { // too much log
-                // MTLog.d(LOG_TAG, "makeCachedStatusFromAgencyData() > IGNORE: wrong route ID '$rtRouteIdHash' (t:$targetRouteIdHash)")
+                // MTLog.d(LOG_TAG, "match() > IGNORE: wrong route ID '$rtRouteIdHash' (t:$targetRouteIdHash)")
                 // }
                 return false // NOT A MATCH
             }
@@ -246,7 +247,7 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
                     if (DEBUG_STATIC_RT_MATCH) {
                         MTLog.d(
                             LOG_TAG,
-                            "makeCachedStatusFromAgencyData() > IGNORE: wrong direction ID '$directionId' for ${td.toStringExt(short = true)}"
+                            "match() > IGNORE: wrong direction ID '$directionId' for ${td.toStringExt(short = true)}"
                         )
                     }
                     return false // NOT A MATCH
@@ -255,10 +256,12 @@ object GTFSRealTimeTripUpdatesProvider : MTLog.Loggable {
         }
         parseTripId(td)?.let { tripId ->
             if (tripId !in staticRDTripIds) {
-                if (DEBUG_STATIC_RT_MATCH) {
-                    MTLog.d(LOG_TAG, "makeCachedStatusFromAgencyData() > IGNORE: wrong trip ID ($tripId) for ${td.toStringExt(short = true)}")
+                if (td.hasRouteId()) {
+                    if (DEBUG_STATIC_RT_MATCH) {
+                        MTLog.d(LOG_TAG, "match() > IGNORE: wrong trip ID ($tripId) for ${td.toStringExt(short = true)}")
+                    }
+                    setTripIdsOutOfSync(true)
                 }
-                setTripIdsOutOfSync(true)
                 return false // NOT A MATCH
             }
         }

--- a/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilterTests.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilterTests.kt
@@ -82,16 +82,16 @@ class GTFSRealTimeTripUpdatesFilterTests {
                     startDate = "20260727"
                     startTime = "151800"
                 }
-                vehicle = vehicleDescriptor {
-                    id = "1234"
-                    label = "hello"
-                }
             },
             tripUpdate {
                 trip = tripDescriptor {
                     tripId = TRIP_ID
                     startDate = "20260727"
                     startTime = "151800"
+                }
+                vehicle = vehicleDescriptor {
+                    id = "1234"
+                    label = "hello"
                 }
             },
         ).filterDuplicatesTrips().let { result ->

--- a/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilterTests.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesFilterTests.kt
@@ -1,0 +1,167 @@
+package org.mtransit.android.commons.provider.status
+
+import com.google.transit.realtime.TripDescriptorKt.modifiedTripSelector
+import com.google.transit.realtime.TripUpdateKt.stopTimeEvent
+import com.google.transit.realtime.TripUpdateKt.stopTimeUpdate
+import com.google.transit.realtime.tripDescriptor
+import com.google.transit.realtime.tripUpdate
+import com.google.transit.realtime.vehicleDescriptor
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optStopTimeUpdateList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class GTFSRealTimeTripUpdatesFilterTests {
+
+    companion object {
+        private const val TRIP_ID = "123456789"
+    }
+
+    @Test
+    fun test_filterDuplicatesTrips_1Regular_2ModifiedTrips() {
+        listOf(
+            tripUpdate {
+                trip = tripDescriptor {
+                    tripId = TRIP_ID
+                    startDate = "20260727"
+                    startTime = "151800"
+                }
+                vehicle = vehicleDescriptor {
+                    id = "1234"
+                    label = "hello"
+                }
+            },
+            tripUpdate {
+                trip = tripDescriptor {
+                    tripId = TRIP_ID
+                    modifiedTrip = modifiedTripSelector {
+                        affectedTripId = TRIP_ID
+                        modificationsId = TRIP_ID
+                        startDate = "20260727"
+                        startTime = "151800"
+                    }
+                }
+                vehicle = vehicleDescriptor {
+                    id = "1234"
+                    label = "hello"
+                }
+            },
+            tripUpdate {
+                trip = tripDescriptor {
+                    tripId = TRIP_ID
+                    modifiedTrip = modifiedTripSelector {
+                        affectedTripId = TRIP_ID
+                        modificationsId = TRIP_ID
+                        startDate = "20260727"
+                        startTime = "151800"
+                    }
+                }
+                vehicle = vehicleDescriptor {
+                    id = "1234"
+                    label = "hello"
+                }
+            },
+        ).filterDuplicatesTrips().let { result ->
+            assert(result.size == 1)
+            assertNotNull(result.getOrNull(0)) {
+                assertEquals(TRIP_ID, it.trip.tripId)
+                assertFalse(it.trip.hasModifiedTrip())
+                assertTrue(it.hasVehicle())
+            }
+        }
+    }
+
+    @Test
+    fun test_filterDuplicatesTrips_2Regulars_W_WO_VehicleDescriptor() {
+        listOf(
+            tripUpdate {
+                trip = tripDescriptor {
+                    tripId = TRIP_ID
+                    startDate = "20260727"
+                    startTime = "151800"
+                }
+                vehicle = vehicleDescriptor {
+                    id = "1234"
+                    label = "hello"
+                }
+            },
+            tripUpdate {
+                trip = tripDescriptor {
+                    tripId = TRIP_ID
+                    startDate = "20260727"
+                    startTime = "151800"
+                }
+            },
+        ).filterDuplicatesTrips().let { result ->
+            assert(result.size == 1)
+            assertNotNull(result.getOrNull(0)) {
+                assertEquals(TRIP_ID, it.trip.tripId)
+                assertFalse(it.trip.hasModifiedTrip())
+                assertTrue(it.hasVehicle())
+            }
+        }
+    }
+
+    @Test
+    fun test_filterDuplicatesTrips_2ModifiedTrips() {
+        listOf(
+            tripUpdate {
+                trip = tripDescriptor {
+                    tripId = TRIP_ID
+                    modifiedTrip = modifiedTripSelector {
+                        affectedTripId = TRIP_ID
+                        modificationsId = TRIP_ID
+                        startDate = "20260727"
+                        startTime = "151800"
+                    }
+                }
+                vehicle = vehicleDescriptor {
+                    id = "1234"
+                    label = "hello"
+                }
+                stopTimeUpdate += stopTimeUpdate {
+                    stopSequence = 25
+                    stopId = "1096"
+                    departure = stopTimeEvent { delay = 39 }
+                }
+                // etc. (all other trip stops until last one)
+            },
+            tripUpdate {
+                trip = tripDescriptor {
+                    tripId = TRIP_ID
+                    modifiedTrip = modifiedTripSelector {
+                        affectedTripId = TRIP_ID
+                        modificationsId = TRIP_ID
+                        startDate = "20260727"
+                        startTime = "151800"
+                    }
+                }
+                vehicle = vehicleDescriptor {
+                    id = "1234"
+                    label = "hello"
+                }
+                stopTimeUpdate += stopTimeUpdate {
+                    stopSequence = 1
+                    stopId = "1001"
+                    departure = stopTimeEvent { delay = 5 }
+                }
+                // etc. (stop time update unrelated to this trip ID (static data) (either trip modification is massive or just vehicle next trip)
+            },
+        ).filterDuplicatesTrips().let { result ->
+            assert(result.size == 1)
+            assertNotNull(result.getOrNull(0)) { gTripUpdate ->
+                assertEquals(TRIP_ID, gTripUpdate.trip.tripId)
+                assertTrue(gTripUpdate.trip.hasModifiedTrip())
+                assertTrue(gTripUpdate.hasVehicle())
+                assertEquals(1, gTripUpdate.stopTimeUpdateCount)
+                assertNotNull(gTripUpdate.optStopTimeUpdateList?.getOrNull(0)) { stu ->
+                    assertEquals(25, stu.stopSequence)
+                    assertEquals("1096", stu.stopId)
+                    assertEquals(39, stu.departure.delay)
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
@@ -17,6 +17,9 @@ import org.mtransit.android.commons.data.makeSchedule
 import org.mtransit.android.commons.data.toScheduleTimestamp
 import org.mtransit.android.commons.provider.gtfs.GTFSStatusProvider
 import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.delayDuration
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optRouteId
+import org.mtransit.android.commons.provider.gtfs.GtfsRealtimeExt.optTripId
+import org.mtransit.android.commons.provider.status.GTFSRealTimeTripUpdatesProvider.match
 import org.mtransit.android.commons.secsToInstant
 import org.mtransit.android.commons.toSecs
 import kotlin.test.Test
@@ -1189,6 +1192,68 @@ class GTFSRealTimeTripUpdatesProviderTests {
         assertNotNull(result[4]) { stu ->
             assertEquals(9, stu.stopSequence)
             assertEquals("9000", stu.stopId)
+        }
+    }
+
+    // endregion
+
+    // region TripDescriptor match
+
+    @Test
+    fun test_match_trip_id_only_matches() {
+        var tripIdsOutOfSync = false
+        tripDescriptor {
+            tripId = TRIP_ID
+        }.match(
+            targetRouteIdHash = "1",
+            targetDirectionOriginalId = 1,
+            staticRDTripIds = setOf(TRIP_ID),
+            ignoreDirection = false,
+            parseRouteId = { it.optRouteId },
+            parseTripId = { it.optTripId },
+            setTripIdsOutOfSync = { tripIdsOutOfSync = it}
+        ).let { result ->
+            assertTrue(result)
+            assertFalse(tripIdsOutOfSync)
+        }
+    }
+
+    @Test
+    fun test_match_trip_id_only_does_not_match() {
+        var tripIdsOutOfSync = false
+        tripDescriptor {
+            tripId = TRIP_ID
+        }.match(
+            targetRouteIdHash = "1",
+            targetDirectionOriginalId = 1,
+            staticRDTripIds = setOf("different_trip_id"),
+            ignoreDirection = false,
+            parseRouteId = { it.optRouteId },
+            parseTripId = { it.optTripId },
+            setTripIdsOutOfSync = { tripIdsOutOfSync = it}
+        ).let { result ->
+            assertFalse(result)
+            assertFalse(tripIdsOutOfSync)
+        }
+    }
+
+    @Test
+    fun test_match_trip_id_and_route_does_not_match() {
+        var tripIdsOutOfSync = false
+        tripDescriptor {
+            routeId = "1"
+            tripId = TRIP_ID
+        }.match(
+            targetRouteIdHash = "1",
+            targetDirectionOriginalId = 1,
+            staticRDTripIds = setOf("different_trip_id"),
+            ignoreDirection = false,
+            parseRouteId = { it.optRouteId },
+            parseTripId = { it.optTripId },
+            setTripIdsOutOfSync = { tripIdsOutOfSync = it}
+        ).let { result ->
+            assertFalse(result)
+            assertTrue(tripIdsOutOfSync)
         }
     }
 

--- a/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
+++ b/src/test/java/org/mtransit/android/commons/provider/status/GTFSRealTimeTripUpdatesProviderTests.kt
@@ -337,7 +337,7 @@ class GTFSRealTimeTripUpdatesProviderTests {
         val tripStart = DEPARTURE
         val gTripUpdate = tripUpdate {
             trip = tripDescriptor {
-                this.tripId = tripId
+                tripId = TRIP_ID
             }
             delayDuration = 1.minutes
         }


### PR DESCRIPTION
The best practices suggest feed publishers to include duplicate trip updates w/ and w/o `ModifiedTripSelector`

- #182